### PR TITLE
Parse pum worktree and pum w

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -215,6 +215,106 @@ describe("CLI argument parsing", () => {
     });
   });
 
+  test("parses both worktree command names with an optional directory", () => {
+    for (const name of ["worktree", "w"]) {
+      expect(parseCliArgs([name])).toEqual({
+        kind: "start",
+        options: { login: false, resume: false, overrideStatsFile: false, worktree: {} },
+      });
+      expect(parseCliArgs([name, "/work/repo"])).toEqual({
+        kind: "start",
+        options: {
+          login: false,
+          resume: false,
+          overrideStatsFile: false,
+          worktree: { directory: "/work/repo" },
+        },
+      });
+      // "login" before the directory stays the keyword, as it does for mounts.
+      expect(parseCliArgs([name, "login"])).toEqual({
+        kind: "start",
+        options: { login: true, resume: false, overrideStatsFile: false, worktree: {} },
+      });
+    }
+  });
+
+  test("keeps a dash-leading or command-like worktree directory reachable", () => {
+    expect(parseCliArgs(["worktree", "--", "-x"])).toEqual({
+      kind: "start",
+      options: {
+        login: false,
+        resume: false,
+        overrideStatsFile: false,
+        worktree: { directory: "-x" },
+      },
+    });
+    expect(parseCliArgs(["w", "--", "login"])).toEqual({
+      kind: "start",
+      options: {
+        login: false,
+        resume: false,
+        overrideStatsFile: false,
+        worktree: { directory: "login" },
+      },
+    });
+    // Other command names in the operand slot are plain directories already.
+    for (const name of ["s", "sr", "ss", "worktree", "w"]) {
+      expect(parseCliArgs(["worktree", name])).toEqual({
+        kind: "start",
+        options: {
+          login: false,
+          resume: false,
+          overrideStatsFile: false,
+          worktree: { directory: name },
+        },
+      });
+    }
+    // The reverse still holds: after "s" a worktree name is a mount.
+    expect(parseCliArgs(["s", "worktree"])).toEqual({
+      kind: "start",
+      options: {
+        login: false,
+        resume: false,
+        overrideStatsFile: false,
+        outerSandbox: { mode: "write", mounts: ["worktree"] },
+      },
+    });
+  });
+
+  test("rejects extra worktree operands and unusable flag combinations", () => {
+    expect(parseCliArgs(["worktree", "/a", "/b"])).toEqual({
+      kind: "error",
+      message: "The worktree command accepts one directory",
+    });
+    expect(parseCliArgs(["w", "--", "/a", "/b"])).toEqual({
+      kind: "error",
+      message: "The worktree command accepts one directory",
+    });
+    expect(parseCliArgs(["worktree", "/a", "login"])).toEqual({
+      kind: "error",
+      message: "'login' must come before the worktree directory",
+    });
+    expect(parseCliArgs(["worktree", "-p", "task"])).toEqual({
+      kind: "error",
+      message: "Cannot combine the worktree command with --prompt",
+    });
+    expect(parseCliArgs(["w", "-r"])).toEqual({
+      kind: "error",
+      message: "Cannot combine the worktree command with --resume",
+    });
+    expect(parseCliArgs(["worktree", "--unknown"])).toEqual({
+      kind: "error",
+      message: "Unknown option: --unknown",
+    });
+    expect(parseCliArgs(["ss", "worktree"])).toEqual({
+      kind: "error",
+      message: "Command 'ss' does not accept arguments or options.",
+    });
+    // Help and version still win over a bad worktree invocation.
+    expect(parseCliArgs(["worktree", "/a", "/b", "-h"])).toEqual({ kind: "help" });
+    expect(parseCliArgs(["-v", "w", "-r"])).toEqual({ kind: "version" });
+  });
+
   test("help and version win over a parse error", () => {
     for (const flag of ["-h", "--help"]) {
       expect(parseCliArgs([flag, "badcmd"])).toEqual({ kind: "help" });
@@ -306,6 +406,8 @@ describe("non-interactive CLI", () => {
       expect(result.stdout).toContain("pum s [login] [options] [directory[:ro|:rw] ...]");
       expect(result.stdout).toContain("pum sr [login] [options] [directory[:ro|:rw] ...]");
       expect(result.stdout).toContain("pum ss");
+      expect(result.stdout).toContain("pum worktree [login] [options] [directory]");
+      expect(result.stdout).toContain("pum w [login] [options] [directory]");
       expect(result.stdout).toContain("--statsFile");
       expect(result.stdout).toContain("PUM_DIR");
       expect(result.stdout).toContain("Executable: pum");
@@ -357,6 +459,38 @@ describe("non-interactive CLI", () => {
 
     const version = await runCli("-v", "badcmd");
     expect(version.exitCode).toBe(0);
+    expect(version.stderr).toBe("");
+    await expectNoStartup(version);
+  });
+
+  test("a bad worktree invocation exits 2 without starting the TUI", async () => {
+    const cases: [string[], string][] = [
+      [["worktree", "/a", "/b"], "The worktree command accepts one directory"],
+      [["w", "--", "/a", "/b"], "The worktree command accepts one directory"],
+      [["worktree", "-p", "task"], "Cannot combine the worktree command with --prompt"],
+      [["w", "-r"], "Cannot combine the worktree command with --resume"],
+      [["worktree", "-x"], "Unknown option: -x"],
+    ];
+    for (const [args, message] of cases) {
+      const result = await runCli(...args);
+      expect(result.exitCode).toBe(2);
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe(formatCliError(message));
+      await expectNoStartup(result);
+    }
+  }, 20_000);
+
+  test("worktree help and version print before the operands are checked", async () => {
+    const metadata = await readPackageMetadata();
+    const help = await runCli("worktree", "/a", "/b", "--help");
+    expect(help.exitCode).toBe(0);
+    expect(help.stdout).toBe(helpText(metadata));
+    expect(help.stderr).toBe("");
+    await expectNoStartup(help);
+
+    const version = await runCli("-v", "w", "-r");
+    expect(version.exitCode).toBe(0);
+    expect(version.stdout).toBe(`${metadata.version}\n`);
     expect(version.stderr).toBe("");
     await expectNoStartup(version);
   });

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -395,6 +395,26 @@ describe("non-interactive CLI", () => {
     }
   });
 
+  test("a worktree that cannot be created fails without starting the TUI", async () => {
+    // The parser accepts any directory, so the only thing standing between a
+    // bad path and a launched TUI is the dispatch. Exit 1, not the parser's 2.
+    const missing = join(temporaryRoot, "definitely-not-here");
+    const result = await runCli("worktree", missing);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("pum:");
+    expect(result.stdout).toBe("");
+    await expectNoStartup(result);
+  });
+
+  test("a directory outside a repository is refused before the TUI loads", async () => {
+    const plain = join(temporaryRoot, "plain-directory");
+    mkdirSync(plain, { recursive: true });
+    const result = await runCli("worktree", plain);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe("");
+    await expectNoStartup(result);
+  });
+
   test("long and short help flags print the manual", async () => {
     const expected = helpText(await readPackageMetadata());
     for (const flag of ["--help", "-h"]) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,10 +11,20 @@ export interface OuterSandboxOptions {
   mounts: string[];
 }
 
+export interface WorktreeOptions {
+  /**
+   * Repository directory the worktree branches from. Undefined means the
+   * current directory; the parser stays pure, so the caller resolves it.
+   */
+  directory?: string;
+}
+
 export interface StartupOptions {
   login: boolean;
   resume: boolean;
   outerSandbox?: OuterSandboxOptions;
+  /** Create an auto-named worktree and start PUM there, for `pum worktree`. */
+  worktree?: WorktreeOptions;
   /** Non-interactive one-shot prompt for `pum -p "<text>"`. */
   prompt?: string;
   /** Optional benchmark statistics output for headless mode. */
@@ -40,6 +50,7 @@ export async function readPackageMetadata(): Promise<PackageMetadata> {
 }
 
 const SETUP_ARGUMENTS_ERROR = "Command 'ss' does not accept arguments or options.";
+const WORKTREE_OPERAND_ERROR = "The worktree command accepts one directory";
 
 export function parseCliArgs(args: string[]): CliResult {
   let login = false;
@@ -52,10 +63,15 @@ export function parseCliArgs(args: string[]): CliResult {
   let version = false;
   let endOfOptions = false;
   let outerSandbox: OuterSandboxOptions | undefined;
+  let worktree: WorktreeOptions | undefined;
   // Help and version win over a bad argument, as they do in most CLIs, so the
   // loop records the first error and keeps reading instead of returning at once.
   let error: string | undefined;
   const fail = (message: string): void => { if (error === undefined) error = message; };
+  const addWorktreeDirectory = (target: WorktreeOptions, value: string): void => {
+    if (target.directory === undefined) target.directory = value;
+    else fail(WORKTREE_OPERAND_ERROR);
+  };
 
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index]!;
@@ -68,6 +84,7 @@ export function parseCliArgs(args: string[]): CliResult {
       // Everything after `--` is an operand, so a mount directory may start
       // with `-` and a directory named `login` stays a directory.
       if (outerSandbox) outerSandbox.mounts.push(arg);
+      else if (worktree) addWorktreeDirectory(worktree, arg);
       else fail(`Unknown command: ${arg}`);
       continue;
     }
@@ -88,7 +105,7 @@ export function parseCliArgs(args: string[]): CliResult {
       statsFile = value;
     } else if (arg === "--override") overrideStatsFile = true;
     else if (arg.startsWith("-")) fail(`Unknown option: ${arg}`);
-    else if (arg === "ss" && !outerSandbox) {
+    else if (arg === "ss" && !outerSandbox && !worktree) {
       if (login || resume || prompt !== undefined || statsFile !== undefined || overrideStatsFile) {
         fail(SETUP_ARGUMENTS_ERROR);
         continue;
@@ -98,10 +115,14 @@ export function parseCliArgs(args: string[]): CliResult {
       // The grammar is `pum s [login] [directory ...]`. A trailing `login` is a
       // mistake, and silently mounting it fails later with a confusing message.
       if (outerSandbox?.mounts.length) fail("'login' must come before mount directories");
+      else if (worktree?.directory !== undefined) fail("'login' must come before the worktree directory");
       else login = true;
-    } else if (!outerSandbox && (arg === "s" || arg === "sr")) {
+    } else if (!outerSandbox && !worktree && (arg === "s" || arg === "sr")) {
       outerSandbox = { mode: arg === "s" ? "write" : "read", mounts: [] };
+    } else if (!outerSandbox && !worktree && (arg === "worktree" || arg === "w")) {
+      worktree = {};
     } else if (outerSandbox) outerSandbox.mounts.push(arg);
+    else if (worktree) addWorktreeDirectory(worktree, arg);
     else fail(`Unknown command: ${arg}`);
   }
 
@@ -112,6 +133,13 @@ export function parseCliArgs(args: string[]): CliResult {
   if (login && prompt !== undefined) return { kind: "error", message: "Cannot combine login with --prompt" };
   if (outerSandbox && prompt !== undefined) {
     return { kind: "error", message: "Cannot combine an outer sandbox command with --prompt" };
+  }
+  if (worktree && prompt !== undefined) {
+    return { kind: "error", message: "Cannot combine the worktree command with --prompt" };
+  }
+  if (worktree && resume) {
+    // A worktree is created fresh, so it has no earlier session to resume.
+    return { kind: "error", message: "Cannot combine the worktree command with --resume" };
   }
   if (prompt !== undefined && prompt.trim() === "") {
     return { kind: "error", message: "The prompt text is empty" };
@@ -133,6 +161,7 @@ export function parseCliArgs(args: string[]): CliResult {
       resume,
       overrideStatsFile,
       ...(outerSandbox ? { outerSandbox } : {}),
+      ...(worktree ? { worktree } : {}),
       ...(prompt !== undefined ? { prompt } : {}),
       ...(statsFile !== undefined ? { statsFile } : {}),
     },
@@ -149,6 +178,8 @@ export function helpText(metadata: PackageMetadata): string {
 Usage:
   pum [options]
   pum login [options]
+  pum worktree [login] [options] [directory]
+  pum w [login] [options] [directory]
   pum s [login] [options] [directory[:ro|:rw] ...]
   pum sr [login] [options] [directory[:ro|:rw] ...]
   pum ss
@@ -164,6 +195,8 @@ Options:
 
 Commands:
   login            Open PUM with the provider login panel.
+  worktree         Create an auto-named Git worktree and start PUM in it.
+  w                Short name for worktree.
   s                Start PUM in a writable outer sandbox.
   sr               Start PUM with the current directory read-only.
   ss               Check the outer sandbox runtime and show setup requirements.
@@ -173,6 +206,13 @@ Sandbox mounts:
   explicit access. PUM validates and canonicalizes every directory before start.
   "login" must come before the directories. Put -- before a directory whose
   name starts with a dash or is called "login".
+
+Worktrees:
+  "pum worktree" and "pum w" create an auto-named worktree of the repository
+  that holds the given directory and start PUM in that worktree. Without a
+  directory PUM uses the current one. Put -- before a directory whose name
+  starts with a dash or is called "login". These commands take no -p and no -r:
+  the new worktree runs the TUI and has no earlier session.
 
 Non-interactive mode:
   "pum -p" runs the coding tools (read, write, edit, apply_patch, bash) with

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -61,6 +61,20 @@ if (result.kind === "help") {
     overrideStatsFile: result.options.overrideStatsFile,
     pumVersion: metadata.version,
   });
+} else if (result.options.worktree) {
+  // Create the worktree before the TUI loads. main.tsx reads process.cwd() as
+  // it mounts, so the move has to happen while nothing has captured it yet.
+  const { startWorktree, worktreeStartMessage } = await import("./worktree-start");
+  try {
+    const started = await startWorktree(result.options.worktree.directory);
+    process.stdout.write(`${worktreeStartMessage(started)}\n`);
+    process.chdir(started.worktree.path);
+    const { start } = await import("./main");
+    await start(result.options, { worktreeSourceRoot: started.sourceRoot });
+  } catch (error) {
+    process.stderr.write(formatCliError(errorMessage(error)));
+    process.exitCode = 1;
+  }
 } else {
   const { start } = await import("./main");
   await start(result.options);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -70,7 +70,19 @@ import {
   lifecycleEventFromSnapshot,
 } from "./shells/lifecycle";
 
-export async function start(options: StartupOptions): Promise<void> {
+/**
+ * Process-local launch context. These are facts about how this process was
+ * started, never user settings, so nothing here reaches pum.json.
+ */
+export type LaunchContext = {
+  /** Source repository of a `pum worktree` launch, authorized as a writable root. */
+  worktreeSourceRoot?: string;
+};
+
+export async function start(
+  options: StartupOptions,
+  context: LaunchContext = {},
+): Promise<void> {
   mkdirSync(AGENT_DIR, { recursive: true });
 
   const modelRuntime = await ModelRuntime.create({
@@ -81,9 +93,13 @@ export async function start(options: StartupOptions): Promise<void> {
 
   const settings = loadSettings();
   const outerSandbox = outerSandboxContext();
-  const forcedCheckPaths = outerSandbox
-    ? outerSandboxAdditionalRoots(outerSandbox, process.cwd())
-    : [];
+  // The source repository joins the outer-sandbox roots rather than the saved
+  // check paths: it is true of this process only, and `/check-path` must not
+  // learn about it.
+  const forcedCheckPaths = [
+    ...(outerSandbox ? outerSandboxAdditionalRoots(outerSandbox, process.cwd()) : []),
+    ...(context.worktreeSourceRoot ? [context.worktreeSourceRoot] : []),
+  ];
   const sandboxController = new SandboxController({
     mode: outerSandbox ? "off" : settings.sandboxMode ?? "auto",
     agentDir: AGENT_DIR,


### PR DESCRIPTION
Part of #13. Argument parsing and help text only; the dispatch and the actual worktree creation are separate units.

- `pum worktree [directory]` and `pum w [directory]` are equivalent. The operand names the repository the worktree branches from. Omitted means the current directory, resolved by the caller so `parseCliArgs` stays pure.
- `--` before the operand keeps a directory named `login` or one starting with `-` reachable, exactly as mount handling does. Other command names in the operand slot are already plain directories.
- A second operand fails with `The worktree command accepts one directory`.
- No `-p` (headless) and no `-r`: a fresh worktree runs the TUI and has no earlier session to resume, which matches "Do not resume the latest source session" in the issue.
- Locked behavior preserved: `-h`/`--help` and `-v`/`--version` still print and exit 0 over a bad worktree invocation, unknown options and commands still exit 2, `--` still ends option parsing.
- Help gains both names under Usage and Commands plus a short Worktrees section.

Tests cover both names, with and without a directory, `--` before a dash-leading or command-like operand, extra operands, conflicting flags, help/version precedence, and the exit codes. Subprocess cases prove a bad invocation exits 2 without starting the TUI.

`bun test` and `bunx tsc --noEmit` are clean; the two failures in the full suite (prompt-input-layout, subagents/ui) are pre-existing on a clean tree.