### PR TITLE
Let a controller answer a questionnaire

### DIFF
--- a/src/questionnaire.test.ts
+++ b/src/questionnaire.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   QuestionnaireManager,
   questionnaireDetail,
+  type QuestionnaireAnswer,
   type QuestionnaireQuestion,
 } from "./questionnaire";
 
@@ -108,6 +109,233 @@ describe("questionnaire controller", () => {
       { id: "main", name: "main" },
       [questions[0]!, { ...questions[1]!, id: "scope" }],
     )).rejects.toThrow("Duplicate questionnaire question id");
+    unsubscribe();
+  });
+});
+
+const scopeAnswer: QuestionnaireAnswer = {
+  questionId: "scope",
+  value: "large",
+  label: "Large",
+  custom: false,
+};
+const formatAnswer: QuestionnaireAnswer = {
+  questionId: "format",
+  value: "json",
+  label: "JSON",
+  custom: false,
+};
+
+describe("questionnaire programmatic completion", () => {
+  test("resolves the pending call with answers in question order", async () => {
+    const { manager, unsubscribe } = mountedManager();
+    const pending = manager.request({ id: "main", name: "main" }, questions);
+    const id = manager.current()!.id;
+
+    // Supplied out of order to prove the reply follows the questions, not the caller.
+    expect(manager.completeCurrent(id, {
+      cancelled: false,
+      answers: [formatAnswer, scopeAnswer],
+    })).toBe(true);
+
+    await expect(pending).resolves.toEqual({
+      cancelled: false,
+      answers: [scopeAnswer, formatAnswer],
+    });
+    expect(manager.current()).toBeUndefined();
+    unsubscribe();
+  });
+
+  test("accepts a custom answer that matches no option", async () => {
+    const { manager, unsubscribe } = mountedManager();
+    const pending = manager.request({ id: "main", name: "main" }, [questions[1]!]);
+
+    expect(manager.completeCurrent(manager.current()!.id, {
+      cancelled: false,
+      answers: [{ questionId: "format", value: "yaml", label: "YAML", custom: true }],
+    })).toBe(true);
+
+    await expect(pending).resolves.toEqual({
+      cancelled: false,
+      answers: [{ questionId: "format", value: "yaml", label: "YAML", custom: true }],
+    });
+    unsubscribe();
+  });
+
+  test("cancels the request the controller named, not whichever is shown later", async () => {
+    const { manager, unsubscribe } = mountedManager();
+    const first = manager.request({ id: "main", name: "main" }, [questions[0]!]);
+    const second = manager.request({ id: "child", name: "child" }, [questions[0]!]);
+    const id = manager.current()!.id;
+
+    expect(manager.completeCurrent(id, { cancelled: true, answers: [] })).toBe(true);
+    await expect(first).resolves.toEqual({ cancelled: true, answers: [] });
+
+    // The queue advanced, so the same id must not reach the promoted request.
+    expect(manager.completeCurrent(id, { cancelled: true, answers: [] })).toBe(false);
+    expect(manager.current()?.requester.id).toBe("child");
+    manager.cancel();
+    await expect(second).resolves.toEqual({ cancelled: true, answers: [] });
+    unsubscribe();
+  });
+
+  test("discards partial popup selections instead of merging them", async () => {
+    const { manager, unsubscribe } = mountedManager();
+    const pending = manager.request({ id: "main", name: "main" }, questions);
+
+    manager.moveOption(1);
+    expect(manager.select()).toBe("selected");
+    expect(manager.current()?.answers.size).toBe(1);
+
+    expect(manager.completeCurrent(manager.current()!.id, {
+      cancelled: false,
+      answers: [
+        { questionId: "scope", value: "small", label: "Small", custom: false },
+        formatAnswer,
+      ],
+    })).toBe(true);
+
+    await expect(pending).resolves.toEqual({
+      cancelled: false,
+      answers: [
+        { questionId: "scope", value: "small", label: "Small", custom: false },
+        formatAnswer,
+      ],
+    });
+    unsubscribe();
+  });
+
+  test("rejects results that do not match the asked questions", async () => {
+    const { manager, unsubscribe } = mountedManager();
+    const pending = manager.request({ id: "main", name: "main" }, questions);
+    const id = manager.current()!.id;
+
+    const rejected: Array<[string, unknown]> = [
+      ["missing an answer", { cancelled: false, answers: [scopeAnswer] }],
+      ["an extra answer", { cancelled: false, answers: [scopeAnswer, formatAnswer, formatAnswer] }],
+      ["a duplicate id", { cancelled: false, answers: [scopeAnswer, scopeAnswer] }],
+      ["an unknown id", {
+        cancelled: false,
+        answers: [scopeAnswer, { ...formatAnswer, questionId: "nope" }],
+      }],
+      ["an unoffered value", {
+        cancelled: false,
+        answers: [{ ...scopeAnswer, value: "huge" }, formatAnswer],
+      }],
+      ["a relabelled option", {
+        cancelled: false,
+        answers: [{ ...scopeAnswer, label: "Huge" }, formatAnswer],
+      }],
+      ["a blank custom answer", {
+        cancelled: false,
+        answers: [{ ...scopeAnswer, value: " ", label: " ", custom: true }, formatAnswer],
+      }],
+      ["a non-string value", {
+        cancelled: false,
+        answers: [{ ...scopeAnswer, value: 1 }, formatAnswer],
+      }],
+      ["a non-boolean custom flag", {
+        cancelled: false,
+        answers: [{ ...scopeAnswer, custom: "yes" }, formatAnswer],
+      }],
+      ["a cancellation carrying answers", { cancelled: true, answers: [scopeAnswer, formatAnswer] }],
+      ["a non-boolean cancelled flag", { cancelled: "no", answers: [scopeAnswer, formatAnswer] }],
+      ["answers that are not a list", { cancelled: false, answers: undefined }],
+    ];
+
+    for (const [reason, result] of rejected) {
+      expect(`${reason}: ${manager.completeCurrent(id, result as any)}`).toBe(`${reason}: false`);
+      expect(manager.current()?.id).toBe(id);
+      expect(manager.current()?.answers.size).toBe(0);
+    }
+
+    // The request survived every rejection, so it can still be answered.
+    expect(manager.completeCurrent(id, {
+      cancelled: false,
+      answers: [scopeAnswer, formatAnswer],
+    })).toBe(true);
+    await expect(pending).resolves.toEqual({
+      cancelled: false,
+      answers: [scopeAnswer, formatAnswer],
+    });
+    unsubscribe();
+  });
+
+  test("ignores a result carrying a stale request id", async () => {
+    const { manager, unsubscribe } = mountedManager();
+    const first = manager.request({ id: "main", name: "main" }, [questions[0]!]);
+    const second = manager.request({ id: "child", name: "child" }, [questions[0]!]);
+    const firstId = manager.current()!.id;
+    const complete = { cancelled: false, answers: [scopeAnswer] };
+
+    // An id belonging to no request at all.
+    expect(manager.completeCurrent(`${firstId}-gone`, complete)).toBe(false);
+
+    manager.cancel();
+    await expect(first).resolves.toEqual({ cancelled: true, answers: [] });
+
+    // Cancelled, and the queue advanced onto a different request.
+    const secondId = manager.current()!.id;
+    expect(secondId).not.toBe(firstId);
+    expect(manager.completeCurrent(firstId, complete)).toBe(false);
+    expect(manager.current()?.id).toBe(secondId);
+
+    expect(manager.completeCurrent(secondId, complete)).toBe(true);
+    await expect(second).resolves.toEqual({ cancelled: false, answers: [scopeAnswer] });
+
+    // Already completed, so the same id must not resolve anything twice.
+    expect(manager.completeCurrent(secondId, complete)).toBe(false);
+    unsubscribe();
+  });
+
+  test("ignores a result for a request its requester already aborted", async () => {
+    const { manager, unsubscribe } = mountedManager();
+    const controller = new AbortController();
+    const pending = manager.request({ id: "main", name: "main" }, [questions[0]!], controller.signal);
+    const id = manager.current()!.id;
+
+    controller.abort();
+    await expect(pending).resolves.toEqual({ cancelled: true, answers: [] });
+    expect(manager.completeCurrent(id, { cancelled: false, answers: [scopeAnswer] })).toBe(false);
+    unsubscribe();
+  });
+
+  test("cancels the shown and queued requests of one requester only", async () => {
+    const { manager, unsubscribe } = mountedManager();
+    const child = { id: "child", name: "child" };
+    const first = manager.request(child, [questions[0]!]);
+    const second = manager.request({ id: "main", name: "main" }, [questions[0]!]);
+    const third = manager.request(child, [questions[0]!]);
+    const fourth = manager.request({ id: "other", name: "other" }, [questions[0]!]);
+
+    manager.cancelRequester("child");
+
+    await expect(first).resolves.toEqual({ cancelled: true, answers: [] });
+    await expect(third).resolves.toEqual({ cancelled: true, answers: [] });
+
+    // Removing the head promotes the next survivor and keeps the rest in order.
+    expect(manager.current()?.requester.id).toBe("main");
+    manager.cancel();
+    await expect(second).resolves.toEqual({ cancelled: true, answers: [] });
+    expect(manager.current()?.requester.id).toBe("other");
+    manager.cancel();
+    await expect(fourth).resolves.toEqual({ cancelled: true, answers: [] });
+    expect(manager.current()).toBeUndefined();
+    unsubscribe();
+  });
+
+  test("leaves other requesters alone and never takes identity from the caller", async () => {
+    const { manager, unsubscribe } = mountedManager();
+    const pending = manager.request({ id: "main", name: "main" }, [questions[0]!]);
+
+    manager.cancelRequester("child");
+    expect(manager.current()?.requester).toEqual({ id: "main", name: "main" });
+
+    expect(manager.completeCurrent(manager.current()!.id, {
+      cancelled: false,
+      answers: [scopeAnswer],
+    })).toBe(true);
+    await expect(pending).resolves.toEqual({ cancelled: false, answers: [scopeAnswer] });
     unsubscribe();
   });
 });

--- a/src/questionnaire.ts
+++ b/src/questionnaire.ts
@@ -237,6 +237,66 @@ export class QuestionnaireManager {
     if (request) this.finish(request, { cancelled: true, answers: [] });
   }
 
+  /** Answers or cancels the shown questionnaire from a controller instead of the popup. */
+  completeCurrent(requestId: string, result: QuestionnaireResult): boolean {
+    const request = this.currentRequest;
+    // The shown request can be replaced between the controller reading it and
+    // answering it — cancelled, aborted, or advanced by the queue — so a result
+    // meant for request A must never resolve request B.
+    if (!request || request.id !== requestId) return false;
+    const answers = this.validatedAnswers(request, result);
+    if (!answers) return false;
+    // The caller supplies the whole set; partial popup selections are dropped.
+    this.finish(request, { cancelled: result.cancelled, answers });
+    return true;
+  }
+
+  /** Cancels every request, shown or queued, that belongs to one requester. */
+  cancelRequester(requesterId: string): void {
+    // Snapshot first: finishing the head promotes the next request, and the
+    // promoted one still has to be checked.
+    for (const request of [this.currentRequest, ...this.queue]) {
+      if (request?.requester.id === requesterId) this.finish(request, { cancelled: true, answers: [] });
+    }
+  }
+
+  // Controller answers get no more trust than tool input: they must cover every
+  // question exactly once, and anything not marked custom must be an option the
+  // request actually offered.
+  private validatedAnswers(
+    request: PendingRequest,
+    result: QuestionnaireResult,
+  ): QuestionnaireAnswer[] | undefined {
+    if (!result || typeof result.cancelled !== "boolean" || !Array.isArray(result.answers)) return undefined;
+    // A cancellation answers nothing, so it has nothing to check against the questions.
+    if (result.cancelled) return result.answers.length === 0 ? [] : undefined;
+    if (result.answers.length !== request.questions.length) return undefined;
+
+    const questions = new Map(request.questions.map((question) => [question.id, question]));
+    const answers = new Map<string, QuestionnaireAnswer>();
+    for (const answer of result.answers) {
+      const question = questions.get(answer?.questionId as string);
+      if (!question || answers.has(question.id)) return undefined;
+      if (typeof answer.value !== "string" || typeof answer.label !== "string") return undefined;
+      if (typeof answer.custom !== "boolean") return undefined;
+      if (answer.custom) {
+        if (!answer.value.trim() || !answer.label.trim()) return undefined;
+      } else if (!question.options.some((option) => option.value === answer.value && option.label === answer.label)) {
+        return undefined;
+      }
+      answers.set(question.id, {
+        questionId: question.id,
+        value: answer.value,
+        label: answer.label,
+        custom: answer.custom,
+      });
+    }
+    return request.questions.flatMap((question) => {
+      const answer = answers.get(question.id);
+      return answer ? [answer] : [];
+    });
+  }
+
   private advance(request: PendingRequest): void {
     request.page = request.page < request.questions.length - 1
       ? request.page + 1


### PR DESCRIPTION
Groundwork for `/afk` (#14): a questionnaire has to be answerable without the popup.

Additive only — no existing behaviour changes.

## `completeCurrent(requestId, result): boolean`
Binds to the shown request. Returns `false` and changes nothing when `requestId` is not the current one, which covers a stale result arriving after a cancel, a requester abort, a queue advance, or an earlier completion.

Validates the supplied `QuestionnaireResult` against the original questions: one answer per question id, no unknown or duplicate ids, and a non-custom answer must match an offered option on both `value` and `label`. A cancellation is accepted only with an empty answer list. Anything else is rejected and the request is left untouched.

The caller supplies a complete replacement set; partial popup selections in `request.answers` are never merged in. On success it resolves through `finish`, so answers come back in question declaration order and the queue promotes as usual.

## `cancelRequester(requesterId): void`
Cancels the shown request and every queued request of that requester, resolving each with `{ cancelled: true, answers: [] }`. Mirrors `SpawnPreviewManager.cancelRequester`, so a questionnaire from a child that disappeared cannot outlive it. Requester identity stays on the request and is never read from caller input.

## Tests
14 tests in `src/questionnaire.test.ts`, all existing ones unchanged: successful completion in declaration order, custom answers, partial selections discarded, id-guarded cancellation, every validation rejection, stale ids after cancel/abort/advance/completion, and `cancelRequester` hitting the head and the queue while leaving other requesters in order.

`bun test` and `bunx tsc --noEmit` are clean. The two failures in the full suite (`prompt input layout`, `subagent transcript UI`) are pre-existing on `main` and untouched here.