### PR TITLE
Complete absolute and home paths too

### DIFF
--- a/src/path-autocomplete.test.ts
+++ b/src/path-autocomplete.test.ts
@@ -1,14 +1,17 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { basename, join } from "node:path";
 import { applyPathCompletion, pathCompletions } from "./path-autocomplete";
 
 let cwd: string | undefined;
+let home: string | undefined;
 
 afterEach(() => {
   if (cwd) rmSync(cwd, { recursive: true, force: true });
+  if (home) rmSync(home, { recursive: true, force: true });
   cwd = undefined;
+  home = undefined;
 });
 
 function project() {
@@ -23,6 +26,20 @@ function project() {
   mkdirSync(join(cwd, ".ssh"));
   writeFileSync(join(cwd, ".ssh", "config"), "secret");
   return cwd;
+}
+
+/**
+ * os.homedir() answers from the account, not from $HOME, so a home test needs a
+ * throwaway directory in the real home. Returns its name for `~/<name>/` fragments.
+ */
+function homeSandbox() {
+  home = mkdtempSync(join(homedir(), ".pum-path-"));
+  mkdirSync(join(home, "notes"));
+  mkdirSync(join(home, "my papers"));
+  writeFileSync(join(home, "todo.md"), "");
+  mkdirSync(join(home, ".ssh"));
+  writeFileSync(join(home, ".ssh", "id_rsa"), "secret");
+  return { directory: home, name: basename(home) };
 }
 
 describe("path autocomplete", () => {
@@ -71,5 +88,97 @@ describe("path autocomplete", () => {
       symlinkSync(join(root, "src"), join(root, "linked-src"));
       expect(pathCompletions("linked-src/", 11, root)).toEqual([]);
     }
+  });
+
+  test("completes an absolute fragment outside the project", () => {
+    const root = project();
+    const outside = mkdtempSync(join(tmpdir(), "pum-path-outside-"));
+    try {
+      mkdirSync(join(outside, "reports"));
+      writeFileSync(join(outside, "readme.md"), "");
+      const typed = `read ${outside}/re`;
+      expect(pathCompletions(typed, typed.length, root).map((item) => item.replacement)).toEqual([
+        `${outside}/readme.md`,
+        `${outside}/reports/`,
+      ]);
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  test("expands a home fragment and keeps the ~ in the replacement", () => {
+    const root = project();
+    const { name } = homeSandbox();
+    const typed = `open ~/${name}/no`;
+    expect(pathCompletions(typed, typed.length, root).map((item) => item.replacement)).toEqual([
+      `~/${name}/notes/`,
+    ]);
+    const reference = `open @~/${name}/todo`;
+    expect(pathCompletions(reference, reference.length, root)[0]?.replacement)
+      .toBe(`@~/${name}/todo.md`);
+    const quoted = `open "~/${name}/my p`;
+    expect(pathCompletions(quoted, quoted.length, root)[0]?.replacement)
+      .toBe(`~/${name}/my papers/`);
+  });
+
+  test("lists the home directory for a bare ~", () => {
+    const root = project();
+    const { name } = homeSandbox();
+    const replacements = pathCompletions("~", 1, root).map((item) => item.replacement);
+
+    expect(replacements).toContain(`~/${name}/`);
+    expect(replacements.every((item) => item.startsWith("~/"))).toBe(true);
+    expect(replacements).not.toContain("~/.ssh/");
+  });
+
+  test("treats ~user as a relative fragment", () => {
+    const root = project();
+    mkdirSync(join(root, "~alice"));
+    expect(pathCompletions("~a", 2, root).map((item) => item.replacement)).toEqual(["~alice/"]);
+  });
+
+  test("hides credentials and symbolic links outside the project", () => {
+    const root = project();
+    const { directory, name } = homeSandbox();
+    const partial = `~/${name}/.ss`;
+    expect(pathCompletions(partial, partial.length, root)).toEqual([]);
+    const inside = `~/${name}/.ssh/`;
+    expect(pathCompletions(inside, inside.length, root)).toEqual([]);
+    const absolute = `${directory}/.ssh/id`;
+    expect(pathCompletions(absolute, absolute.length, root)).toEqual([]);
+
+    if (process.platform !== "win32") {
+      symlinkSync(join(directory, "notes"), join(directory, "linked-notes"));
+      const linked = `~/${name}/linked`;
+      expect(pathCompletions(linked, linked.length, root)).toEqual([]);
+    }
+  });
+
+  test("returns nothing for a directory it cannot read", () => {
+    const root = project();
+    const outside = mkdtempSync(join(tmpdir(), "pum-path-locked-"));
+    // Root ignores the permission bits, so only test the denial as a normal user.
+    const canDeny = process.platform !== "win32" && process.getuid?.() !== 0;
+    try {
+      const missing = `${outside}/gone/x`;
+      expect(pathCompletions(missing, missing.length, root)).toEqual([]);
+
+      if (canDeny) {
+        mkdirSync(join(outside, "locked"));
+        writeFileSync(join(outside, "locked", "note.txt"), "");
+        chmodSync(join(outside, "locked"), 0o000);
+        const locked = `${outside}/locked/n`;
+        expect(pathCompletions(locked, locked.length, root)).toEqual([]);
+      }
+    } finally {
+      if (canDeny) chmodSync(join(outside, "locked"), 0o700);
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  test("ignores URL-looking fragments", () => {
+    const root = project();
+    expect(pathCompletions("see https://example.com/sr", 26, root)).toEqual([]);
+    expect(pathCompletions("see file:///etc/ho", 18, root)).toEqual([]);
   });
 });

--- a/src/path-autocomplete.test.ts
+++ b/src/path-autocomplete.test.ts
@@ -30,7 +30,8 @@ function project() {
 
 /**
  * os.homedir() answers from the account, not from $HOME, so a home test needs a
- * throwaway directory in the real home. Returns its name for `~/<name>/` fragments.
+ * throwaway directory in the real home; afterEach removes it. Returns its name
+ * for `~/<name>/` fragments.
  */
 function homeSandbox() {
   home = mkdtempSync(join(homedir(), ".pum-path-"));
@@ -38,7 +39,6 @@ function homeSandbox() {
   mkdirSync(join(home, "my papers"));
   writeFileSync(join(home, "todo.md"), "");
   mkdirSync(join(home, ".ssh"));
-  writeFileSync(join(home, ".ssh", "id_rsa"), "secret");
   return { directory: home, name: basename(home) };
 }
 
@@ -127,8 +127,8 @@ describe("path autocomplete", () => {
     const replacements = pathCompletions("~", 1, root).map((item) => item.replacement);
 
     expect(replacements).toContain(`~/${name}/`);
-    expect(replacements.every((item) => item.startsWith("~/"))).toBe(true);
-    expect(replacements).not.toContain("~/.ssh/");
+    // A bare `~` must list exactly what `~/` lists.
+    expect(replacements).toEqual(pathCompletions("~/", 2, root).map((item) => item.replacement));
   });
 
   test("treats ~user as a relative fragment", () => {
@@ -146,6 +146,13 @@ describe("path autocomplete", () => {
     expect(pathCompletions(inside, inside.length, root)).toEqual([]);
     const absolute = `${directory}/.ssh/id`;
     expect(pathCompletions(absolute, absolute.length, root)).toEqual([]);
+    // An empty basename lists everything, so the filter is the only thing hiding .ssh.
+    const listing = `~/${name}/`;
+    expect(pathCompletions(listing, listing.length, root).map((item) => item.replacement)).toEqual([
+      `~/${name}/my papers/`,
+      `~/${name}/notes/`,
+      `~/${name}/todo.md`,
+    ]);
 
     if (process.platform !== "win32") {
       symlinkSync(join(directory, "notes"), join(directory, "linked-notes"));
@@ -159,14 +166,16 @@ describe("path autocomplete", () => {
     const outside = mkdtempSync(join(tmpdir(), "pum-path-locked-"));
     // Root ignores the permission bits, so only test the denial as a normal user.
     const canDeny = process.platform !== "win32" && process.getuid?.() !== 0;
+    if (canDeny) {
+      mkdirSync(join(outside, "locked"));
+      writeFileSync(join(outside, "locked", "note.txt"), "");
+      chmodSync(join(outside, "locked"), 0o000);
+    }
     try {
       const missing = `${outside}/gone/x`;
       expect(pathCompletions(missing, missing.length, root)).toEqual([]);
 
       if (canDeny) {
-        mkdirSync(join(outside, "locked"));
-        writeFileSync(join(outside, "locked", "note.txt"), "");
-        chmodSync(join(outside, "locked"), 0o000);
         const locked = `${outside}/locked/n`;
         expect(pathCompletions(locked, locked.length, root)).toEqual([]);
       }

--- a/src/path-autocomplete.ts
+++ b/src/path-autocomplete.ts
@@ -1,4 +1,5 @@
 import { lstatSync, readdirSync, realpathSync } from "node:fs";
+import { homedir } from "node:os";
 import { isAbsolute, join, relative, resolve, sep } from "node:path";
 import { isCredentialSensitivePath } from "./credential-path";
 
@@ -86,6 +87,32 @@ function hasSymlinkComponent(root: string, candidate: string): boolean {
   return false;
 }
 
+/** Leading `~` or `~/`, the only home forms we expand. A `~user` names somebody else. */
+const HOME_PREFIX = /^~(?:[/\\]|$)/u;
+
+function isHomeFragment(fragment: string): boolean {
+  const next = fragment[1];
+  return fragment[0] === "~"
+    && (next === undefined || next === "/" || (process.platform === "win32" && next === "\\"));
+}
+
+/**
+ * Locate the directory a fragment lists, plus the root it may not leave.
+ * Absolute and home fragments name their own place, so they answer to no root.
+ */
+function resolveTarget(
+  fragment: string,
+  directory: string,
+  cwd: string,
+): { target: string; root: string | null } {
+  if (isHomeFragment(fragment)) {
+    return { target: resolve(homedir(), directory.replace(HOME_PREFIX, "")), root: null };
+  }
+  if (isAbsolute(fragment)) return { target: resolve(directory), root: null };
+  const root = realpathSync(cwd);
+  return { target: resolve(root, directory || "."), root };
+}
+
 function pathParts(fragment: string): { directory: string; basename: string; separator: string } {
   const slash = fragment.lastIndexOf("/");
   const backslash = process.platform === "win32" ? fragment.lastIndexOf("\\") : -1;
@@ -98,7 +125,8 @@ function pathParts(fragment: string): { directory: string; basename: string; sep
 }
 
 /**
- * List safe project-local path completions for the token under the cursor.
+ * List safe path completions for the token under the cursor. A relative token
+ * stays inside the project; an absolute or `~` token completes where it points.
  * The function excludes credential paths, special files, and symbolic links.
  */
 export function pathCompletions(
@@ -111,19 +139,21 @@ export function pathCompletions(
   const parts = pathParts(token.fragment);
 
   try {
-    const root = realpathSync(cwd);
-    const requestedDirectory = parts.directory || ".";
-    const absoluteDirectory = resolve(root, requestedDirectory);
-    if (!insideOrSame(root, absoluteDirectory) || isCredentialSensitivePath(absoluteDirectory)) return [];
-    const directory = realpathSync(absoluteDirectory);
-    if (
-      !insideOrSame(root, directory)
-      || isCredentialSensitivePath(directory)
-      || hasSymlinkComponent(root, absoluteDirectory)
-    ) return [];
+    const { target, root } = resolveTarget(token.fragment, parts.directory, cwd);
+    if (isCredentialSensitivePath(target)) return [];
+    if (root && !insideOrSame(root, target)) return [];
+    const directory = realpathSync(target);
+    if (isCredentialSensitivePath(directory)) return [];
+    // Outside the project there is nothing to escape from, so the symlink walk
+    // only guards the relative case; the credential checks above cover the rest.
+    if (root && (!insideOrSame(root, directory) || hasSymlinkComponent(root, target))) return [];
 
+    // A bare `~` is the home directory itself, not a name to match inside it.
+    const bareHome = !parts.directory && isHomeFragment(token.fragment);
+    const prefixDirectory = bareHome ? `~${parts.separator}` : parts.directory;
+    const basename = bareHome ? "" : parts.basename;
     const caseSensitive = process.platform !== "win32";
-    const expected = caseSensitive ? parts.basename : parts.basename.toLowerCase();
+    const expected = caseSensitive ? basename : basename.toLowerCase();
     return readdirSync(directory, { withFileTypes: true })
       .filter((entry) => entry.isDirectory() || entry.isFile())
       .filter((entry) => !entry.isSymbolicLink())
@@ -137,7 +167,7 @@ export function pathCompletions(
         start: token.start,
         end: token.end,
         replacement: token.prefix
-          + parts.directory
+          + prefixDirectory
           + entry.name
           + (entry.isDirectory() ? parts.separator : ""),
       }));

--- a/src/path-autocomplete.ts
+++ b/src/path-autocomplete.ts
@@ -126,8 +126,10 @@ function pathParts(fragment: string): { directory: string; basename: string; sep
 
 /**
  * List safe path completions for the token under the cursor. A relative token
- * stays inside the project; an absolute or `~` token completes where it points.
- * The function excludes credential paths, special files, and symbolic links.
+ * stays inside the project and may not reach it through a symbolic link; an
+ * absolute or `~` token names its own place, so a linked directory it spells
+ * out is followed. Either way the function offers no credential path, no
+ * special file, and no symbolic link.
  */
 export function pathCompletions(
   input: string,


### PR DESCRIPTION
Tab path completion only listed files inside the project, so `/etc/ho` and `~/no` returned nothing and `~` was never expanded (it resolved to a nonexistent `<cwd>/~/`).

`pathCompletions` now picks a base per fragment:

- **absolute** (`/…`, and a drive-qualified path on Windows) — lists where it points
- **home** (`~` or `~/…`) — lists under `os.homedir()`; `~user` stays an ordinary relative fragment, since guessing another user's home would be wrong
- **relative** — unchanged, still confined to the project

Everything that made the old function safe survives, and matters more now that it can leave the project: `isCredentialSensitivePath` still runs on the directory and on every entry, which is what keeps `~/.ssh` and `~/.aws` out of the prompt; symlinks, sockets and devices are still excluded; the whole body still returns `[]` on any throw, so a permission error outside the project is silent.

`hasSymlinkComponent` walks `relative(root, candidate)` and means nothing once the candidate sits outside `root`, so it now guards only the relative case — the case where escaping the project is the actual risk.

The output contract is untouched: same `{start, end, replacement}`, the `@` prefix carried through, trailing separator on directories, platform separator choice, Windows-only case folding, `localeCompare` order. `applyPathCompletion` needed no change.

## Tests

11 tests in `src/path-autocomplete.test.ts` cover an absolute fragment, `~/`, bare `~`, `~user` falling back to relative, the unchanged relative behavior, the credential filter firing outside the project, symlink exclusion, a quoted fragment with spaces, the `@` prefix, an unreadable and a missing directory, and URL-looking fragments. Home tests use a throwaway directory inside the real home, since `os.homedir()` under Bun answers from the account and ignores `$HOME`.

`bun test` and `bunx tsc --noEmit` are clean; the two failures in the full suite (`prompt input layout`, `subagent transcript UI`) reproduce on a clean checkout of `main`.

## Note for the coordinator

`src/app.tsx` is untouched. Its Tab handler prefers slash commands when `commandMatches.length > 0 && !/\s/.test(inputValue)`, so an absolute path typed at the start of an empty prompt (`/c…`) still resolves to `/clear` before it can complete a path. See the report for a suggested one-line precedence fix.
