### PR TITLE
Stop a status assertion from depending on the checkout name

### DIFF
--- a/src/subagents/ui.test.tsx
+++ b/src/subagents/ui.test.tsx
@@ -275,7 +275,7 @@ describe("subagent transcript UI", () => {
   });
 
   test("restores main usage and resets it for a new session", async () => {
-    const setup = await createTestRenderer({ width: 120, height: 24, kittyKeyboard: true });
+    const setup = await createTestRenderer({ width: 200, height: 24, kittyKeyboard: true });
     destroy = () => setup.renderer.destroy();
     const resumed = fakeSession([{
       type: "message",


### PR DESCRIPTION
`restores main usage and resets it for a new session` asserted the whole
concatenated status string at width 120:

    ↑ 1.3k · ↓ 345 · ↺ 2.4k · $0.250 · 12%

That only fits when the checkout directory and branch are short. Run the
suite from a git worktree and the status bar drops the cost segment under
width pressure — correct behaviour, but the test reads it as a failure:

     pum  mock-model · off   agent-af8f7e983eb34b5c6 · feat/questionnaire-controller-api · ↑ 1.3k · ↓ 345 · ↺ 2.4k · 12%

The test is about restoring and resetting usage, not about how the status
bar sheds segments when it runs out of room, so give it a terminal wide
enough that the ambient names cannot matter.

This matters now because issue #13 adds a flow that runs PUM from a
generated worktree, and because every parallel agent working in a worktree
reports this as a pre-existing failure.