### PR TITLE
Add the todo model and its companion file

### DIFF
--- a/src/todo.test.ts
+++ b/src/todo.test.ts
@@ -1,0 +1,364 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import {
+  MAX_TODOS,
+  MAX_TODO_TEXT,
+  TODO_STATUSES,
+  addTodoTask,
+  createTodoTask,
+  deleteTodoTask,
+  isTodoStatus,
+  loadTodoTasks,
+  normalizeTodoText,
+  saveTodoTasks,
+  sortTodoTasks,
+  todoFileFor,
+  updateTodoTask,
+  updateTodoTasks,
+  type TodoTask,
+} from "./todo";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function tempSessionFile(): string {
+  const directory = mkdtempSync(join(tmpdir(), "pum-todo-"));
+  temporaryDirectories.push(directory);
+  return join(directory, "session-id.jsonl");
+}
+
+function task(partial: Partial<TodoTask> = {}): TodoTask {
+  return {
+    id: "task-1",
+    text: "write the parser",
+    status: "pending",
+    createdAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_000_000,
+    ...partial,
+  };
+}
+
+describe("task creation", () => {
+  test("trims the text and defaults to pending", () => {
+    expect(createTodoTask("  write the parser  ", undefined, 42, "task-1")).toEqual({
+      id: "task-1",
+      text: "write the parser",
+      status: "pending",
+      createdAt: 42,
+      updatedAt: 42,
+    });
+  });
+
+  test("keeps a supplied valid status", () => {
+    expect(createTodoTask("ship it", "active", 42, "task-1").status).toBe("active");
+  });
+
+  test("rejects empty, blank and overlong text", () => {
+    expect(() => createTodoTask("")).toThrow("a task needs text");
+    expect(() => createTodoTask("   ")).toThrow("a task needs text");
+    expect(() => createTodoTask("\n\t")).toThrow("a task needs text");
+    expect(() => createTodoTask("x".repeat(MAX_TODO_TEXT + 1))).toThrow(String(MAX_TODO_TEXT));
+  });
+
+  test("rejects NUL and escape, and folds a newline into one space", () => {
+    expect(() => createTodoTask("bad\0text")).toThrow("control characters");
+    expect(() => createTodoTask("clear\u001b[2Jthe screen")).toThrow("control characters");
+    expect(normalizeTodoText("write  the\n\tparser")).toBe("write the parser");
+  });
+
+  test("accepts text at exactly the limit", () => {
+    expect(normalizeTodoText("x".repeat(MAX_TODO_TEXT))).toHaveLength(MAX_TODO_TEXT);
+  });
+
+  test("rejects an unknown status", () => {
+    expect(() => createTodoTask("ship it", "done")).toThrow("unknown task status");
+    expect(isTodoStatus("done")).toBe(false);
+    expect(TODO_STATUSES.every(isTodoStatus)).toBe(true);
+  });
+});
+
+describe("canonical order", () => {
+  test("orders by status, then oldest first, then id", () => {
+    const tasks: TodoTask[] = [
+      task({ id: "e", status: "cancelled", createdAt: 1 }),
+      task({ id: "d", status: "completed", createdAt: 1 }),
+      task({ id: "c", status: "blocked", createdAt: 1 }),
+      task({ id: "b", status: "pending", createdAt: 1 }),
+      task({ id: "a", status: "active", createdAt: 1 }),
+    ];
+    expect(sortTodoTasks(tasks).map((entry) => entry.id)).toEqual(["a", "b", "c", "d", "e"]);
+  });
+
+  test("breaks a status tie by createdAt then by id", () => {
+    const tasks: TodoTask[] = [
+      task({ id: "z", createdAt: 5 }),
+      task({ id: "a", createdAt: 9 }),
+      task({ id: "b", createdAt: 5 }),
+    ];
+    expect(sortTodoTasks(tasks).map((entry) => entry.id)).toEqual(["b", "z", "a"]);
+  });
+
+  test("leaves the input untouched", () => {
+    const tasks: TodoTask[] = [task({ id: "b", status: "completed" }), task({ id: "a" })];
+    sortTodoTasks(tasks);
+    expect(tasks.map((entry) => entry.id)).toEqual(["b", "a"]);
+  });
+});
+
+describe("mutation", () => {
+  test("appends and rejects a duplicate id", () => {
+    const one = addTodoTask([], "first", undefined, 1, "task-1");
+    expect(one).toHaveLength(1);
+    expect(() => addTodoTask(one, "again", undefined, 2, "task-1")).toThrow("duplicate task id");
+  });
+
+  test("updates text and status and bumps updatedAt", () => {
+    const tasks = [task()];
+    const next = updateTodoTask(tasks, "task-1", { status: "active" }, 99);
+    expect(next[0]).toMatchObject({ status: "active", updatedAt: 99 });
+    expect(tasks[0]?.status).toBe("pending");
+  });
+
+  test("leaves updatedAt alone when nothing changes", () => {
+    const next = updateTodoTask([task()], "task-1", { text: "write the parser" }, 99);
+    expect(next[0]?.updatedAt).toBe(1_700_000_000_000);
+  });
+
+  test("rejects an unknown id, unknown status and bad text", () => {
+    expect(() => updateTodoTask([task()], "nope", { status: "active" })).toThrow("unknown task id");
+    expect(() => updateTodoTask([task()], "task-1", { status: "done" })).toThrow("unknown task status");
+    expect(() => updateTodoTask([task()], "task-1", { text: "" })).toThrow("a task needs text");
+    expect(() => deleteTodoTask([task()], "nope")).toThrow("unknown task id");
+  });
+
+  test("deletes only the named task", () => {
+    const tasks = [task({ id: "a" }), task({ id: "b", status: "completed" })];
+    expect(deleteTodoTask(tasks, "a").map((entry) => entry.id)).toEqual(["b"]);
+  });
+});
+
+describe("the task cap", () => {
+  function fill(count: number): TodoTask[] {
+    return Array.from({ length: count }, (_unused, index) =>
+      task({ id: `task-${index}`, createdAt: index }));
+  }
+
+  test("accepts the hundredth task and rejects the hundred and first", () => {
+    const full = addTodoTask(fill(MAX_TODOS - 1), "last", undefined, 1, "task-last");
+    expect(full).toHaveLength(MAX_TODOS);
+    expect(() => addTodoTask(full, "one too many", undefined, 2, "task-extra"))
+      .toThrow(`at most ${MAX_TODOS}`);
+  });
+
+  test("counts completed and cancelled tasks too", () => {
+    const finished = fill(MAX_TODOS).map((entry, index) => ({
+      ...entry,
+      status: index % 2 === 0 ? ("completed" as const) : ("cancelled" as const),
+    }));
+    expect(() => addTodoTask(finished, "one more", undefined, 1, "task-extra"))
+      .toThrow(`at most ${MAX_TODOS}`);
+  });
+});
+
+describe("the companion file path", () => {
+  test("sits beside the session with the host separator", () => {
+    const sessionFile = join("some", "dir", "session-id.jsonl");
+    const file = todoFileFor(sessionFile);
+    expect(basename(file)).toBe("session-id.todo.json");
+    expect(dirname(file)).toBe(join("some", "dir"));
+  });
+
+  test("strips a .json session suffix as well", () => {
+    expect(basename(todoFileFor(join("d", "abc.json")))).toBe("abc.todo.json");
+  });
+});
+
+describe("persistence", () => {
+  test("round-trips a saved list", () => {
+    const sessionFile = tempSessionFile();
+    const tasks = [task({ id: "a" }), task({ id: "b", status: "completed" })];
+    saveTodoTasks(sessionFile, tasks);
+    expect(loadTodoTasks(sessionFile)).toEqual(tasks);
+  });
+
+  test("leaves no temp file behind and renames into place", () => {
+    const sessionFile = tempSessionFile();
+    saveTodoTasks(sessionFile, [task()]);
+    const written = readdirSync(dirname(sessionFile));
+    expect(written).toEqual(["session-id.todo.json"]);
+  });
+
+  test("writes nothing for an empty list with no file", () => {
+    const sessionFile = tempSessionFile();
+    saveTodoTasks(sessionFile, []);
+    expect(existsSync(todoFileFor(sessionFile))).toBe(false);
+    expect(loadTodoTasks(sessionFile)).toEqual([]);
+  });
+
+  test("clears an existing file down to an empty list", () => {
+    const sessionFile = tempSessionFile();
+    saveTodoTasks(sessionFile, [task()]);
+    saveTodoTasks(sessionFile, []);
+    expect(loadTodoTasks(sessionFile)).toEqual([]);
+    expect(existsSync(todoFileFor(sessionFile))).toBe(true);
+  });
+
+  test("holds a sessionless list in memory instead of a file", () => {
+    expect(loadTodoTasks(undefined)).toEqual([]);
+    saveTodoTasks(undefined, [task()]);
+    expect(loadTodoTasks(undefined)).toEqual([task()]);
+    saveTodoTasks(undefined, []);
+    expect(loadTodoTasks(undefined)).toEqual([]);
+  });
+
+  test("returns an empty list for corrupt, non-array and missing files", () => {
+    const sessionFile = tempSessionFile();
+    expect(loadTodoTasks(sessionFile)).toEqual([]);
+    writeFileSync(todoFileFor(sessionFile), "{ not json", "utf8");
+    expect(loadTodoTasks(sessionFile)).toEqual([]);
+    writeFileSync(todoFileFor(sessionFile), JSON.stringify({ tasks: [] }), "utf8");
+    expect(loadTodoTasks(sessionFile)).toEqual([]);
+  });
+
+  test("drops invalid entries instead of failing the whole load", () => {
+    const sessionFile = tempSessionFile();
+    writeFileSync(todoFileFor(sessionFile), JSON.stringify([
+      task({ id: "good" }),
+      null,
+      "task",
+      { ...task({ id: "no-status" }), status: "done" },
+      { ...task({ id: "blank" }), text: "   " },
+      { ...task({ id: "nul" }), text: "bad\0text" },
+      { ...task({ id: "long" }), text: "x".repeat(MAX_TODO_TEXT + 1) },
+      { ...task({ id: "" }) },
+      { ...task({ id: "no-time" }), createdAt: "yesterday" },
+      task({ id: "also-good", status: "active" }),
+    ]), "utf8");
+    expect(loadTodoTasks(sessionFile).map((entry) => entry.id)).toEqual(["good", "also-good"]);
+  });
+
+  test("keeps the first of two entries sharing an id", () => {
+    const sessionFile = tempSessionFile();
+    writeFileSync(todoFileFor(sessionFile), JSON.stringify([
+      task({ id: "dupe", text: "first" }),
+      task({ id: "dupe", text: "second" }),
+    ]), "utf8");
+    const loaded = loadTodoTasks(sessionFile);
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0]?.text).toBe("first");
+  });
+
+  test("caps an oversized file by dropping the lowest-priority tasks", () => {
+    const sessionFile = tempSessionFile();
+    writeFileSync(todoFileFor(sessionFile), JSON.stringify([
+      ...Array.from({ length: MAX_TODOS + 19 }, (_unused, index) =>
+        task({ id: `done-${index}`, status: "completed", createdAt: index })),
+      task({ id: "still-running", status: "active", createdAt: 5_000 }),
+    ]), "utf8");
+    const loaded = loadTodoTasks(sessionFile);
+    expect(loaded).toHaveLength(MAX_TODOS);
+    // The active task sits last in the file and must survive the cap.
+    expect(loaded.map((entry) => entry.id)).toContain("still-running");
+  });
+
+  test("keeps file order when the file fits", () => {
+    const sessionFile = tempSessionFile();
+    const tasks = [task({ id: "b", status: "completed" }), task({ id: "a", status: "active" })];
+    saveTodoTasks(sessionFile, tasks);
+    expect(loadTodoTasks(sessionFile).map((entry) => entry.id)).toEqual(["b", "a"]);
+  });
+});
+
+describe("serialized updates", () => {
+  test("keeps every task when writers run in parallel", async () => {
+    const sessionFile = tempSessionFile();
+    const results = await Promise.all(
+      Array.from({ length: 10 }, (_unused, index) =>
+        updateTodoTasks(sessionFile, (tasks) =>
+          addTodoTask(tasks, `task ${index}`, undefined, index, `task-${index}`))),
+    );
+    expect(results.at(-1)).toHaveLength(10);
+    expect(loadTodoTasks(sessionFile)).toHaveLength(10);
+  });
+
+  test("holds the cap against parallel writers", async () => {
+    const sessionFile = tempSessionFile();
+    saveTodoTasks(sessionFile, Array.from({ length: MAX_TODOS - 1 }, (_unused, index) =>
+      task({ id: `seed-${index}`, createdAt: index })));
+    const settled = await Promise.allSettled(
+      Array.from({ length: 3 }, (_unused, index) =>
+        updateTodoTasks(sessionFile, (tasks) =>
+          addTodoTask(tasks, `late ${index}`, undefined, index, `late-${index}`))),
+    );
+    expect(settled.filter((entry) => entry.status === "fulfilled")).toHaveLength(1);
+    expect(loadTodoTasks(sessionFile)).toHaveLength(MAX_TODOS);
+  });
+
+  test("a rejected mutation leaves the file untouched", async () => {
+    const sessionFile = tempSessionFile();
+    await updateTodoTasks(sessionFile, (tasks) =>
+      addTodoTask(tasks, "keep me", undefined, 1, "task-1"));
+    const before = readFileSync(todoFileFor(sessionFile), "utf8");
+    await expect(updateTodoTasks(sessionFile, (tasks) =>
+      updateTodoTask(tasks, "gone", { status: "completed" }))).rejects.toThrow("unknown task id");
+    expect(readFileSync(todoFileFor(sessionFile), "utf8")).toBe(before);
+  });
+
+  test("a rejection does not poison later writers", async () => {
+    const sessionFile = tempSessionFile();
+    const failed = updateTodoTasks(sessionFile, () => {
+      throw new Error("boom");
+    });
+    const added = updateTodoTasks(sessionFile, (tasks) =>
+      addTodoTask(tasks, "after the failure", undefined, 1, "task-1"));
+    await expect(failed).rejects.toThrow("boom");
+    expect(await added).toHaveLength(1);
+  });
+
+  test("refuses to store a duplicate id a mutation invents", async () => {
+    const sessionFile = tempSessionFile();
+    await expect(updateTodoTasks(sessionFile, () => [task({ id: "same" }), task({ id: "same" })]))
+      .rejects.toThrow("duplicate task id");
+    expect(existsSync(todoFileFor(sessionFile))).toBe(false);
+  });
+
+  test("keeps a sessionless list in memory", async () => {
+    try {
+      expect(await updateTodoTasks(undefined, (tasks) =>
+        addTodoTask(tasks, "nowhere", undefined, 1, "task-1"))).toHaveLength(1);
+      expect(loadTodoTasks(undefined).map((entry) => entry.text)).toEqual(["nowhere"]);
+      expect(await updateTodoTasks(undefined, (tasks) =>
+        deleteTodoTask(tasks, "task-1"))).toEqual([]);
+      await expect(updateTodoTasks(undefined, (tasks) =>
+        deleteTodoTask(tasks, "task-1"))).rejects.toThrow("unknown task id");
+    } finally {
+      saveTodoTasks(undefined, []);
+    }
+  });
+
+  test("reports a failed write instead of claiming success", async () => {
+    const sessionFile = tempSessionFile();
+    // A directory where the companion file belongs fails the rename on every
+    // platform, which is the cheapest stand-in for a full or read-only disk.
+    mkdirSync(todoFileFor(sessionFile));
+    await expect(updateTodoTasks(sessionFile, (tasks) =>
+      addTodoTask(tasks, "unwritable", undefined, 1, "task-1"))).rejects.toThrow();
+    // The temp file goes with it; a failed write leaves nothing behind.
+    expect(readdirSync(dirname(sessionFile))).toEqual(["session-id.todo.json"]);
+  });
+});

--- a/src/todo.ts
+++ b/src/todo.ts
@@ -1,0 +1,292 @@
+import { basename, dirname, join } from "node:path";
+import { existsSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+
+/**
+ * Per-agent todo lists.
+ *
+ * A pure state layer: validation, canonical ordering, and a companion file
+ * beside the session JSONL. Tools and the popup build on this and own no
+ * state of their own, so every writer shares one cap and one order.
+ */
+
+export type TodoStatus = "pending" | "active" | "blocked" | "completed" | "cancelled";
+
+/**
+ * Canonical status order. Sorting and the status guard both read this array,
+ * so a new status can only ever be added in one place.
+ */
+export const TODO_STATUSES: readonly TodoStatus[] = [
+  "active",
+  "pending",
+  "blocked",
+  "completed",
+  "cancelled",
+];
+
+/** Longest task text PUM stores. Longer input is refused, never truncated. */
+export const MAX_TODO_TEXT = 500;
+
+/** The list never holds more than this many tasks, whatever their status. */
+export const MAX_TODOS = 100;
+
+export type TodoTask = {
+  /** Stable opaque identifier. */
+  id: string;
+  /** Non-empty task text, at most MAX_TODO_TEXT characters. */
+  text: string;
+  status: TodoStatus;
+  /** Epoch milliseconds. */
+  createdAt: number;
+  /** Epoch milliseconds of the last accepted change. */
+  updatedAt: number;
+};
+
+export function isTodoStatus(value: unknown): value is TodoStatus {
+  return TODO_STATUSES.includes(value as TodoStatus);
+}
+
+/** Companion file next to the session JSONL: <session>.todo.json */
+export function todoFileFor(sessionFile: string): string {
+  const base = basename(sessionFile).replace(/\.jsonl?$/, "");
+  return join(dirname(sessionFile), `${base}.todo.json`);
+}
+
+/**
+ * NUL truncates the text in C string APIs, and ESC lets task text repaint the
+ * terminal the popup draws it into. Tab, newline and return collapse to a
+ * space before this runs, so only the harmful controls reach it.
+ */
+const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f-\u009f]/;
+
+/** Flatten and check task text. Throws with the reason the caller should show. */
+export function normalizeTodoText(value: unknown): string {
+  if (typeof value !== "string") throw new Error("a task needs text");
+  // A task is one line in the popup, so runs of whitespace become one space.
+  const text = value.replace(/\s+/g, " ").trim();
+  if (!text) throw new Error("a task needs text");
+  if (CONTROL_CHARACTERS.test(text)) {
+    throw new Error("task text cannot hold control characters");
+  }
+  if (text.length > MAX_TODO_TEXT) {
+    throw new Error(`a task is at most ${MAX_TODO_TEXT} characters`);
+  }
+  return text;
+}
+
+function normalizeStatus(value: unknown): TodoStatus {
+  if (value === undefined) return "pending";
+  if (!isTodoStatus(value)) throw new Error(`unknown task status: ${String(value)}`);
+  return value;
+}
+
+export function createTodoTask(
+  text: string,
+  status?: unknown,
+  now = Date.now(),
+  id = randomUUID().slice(0, 12),
+): TodoTask {
+  return {
+    id,
+    text: normalizeTodoText(text),
+    status: normalizeStatus(status),
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+/**
+ * Canonical order: status, then oldest first, then id so two tasks written in
+ * the same millisecond never swap places between renders.
+ */
+export function sortTodoTasks(tasks: readonly TodoTask[]): TodoTask[] {
+  return [...tasks].sort((left, right) => {
+    const byStatus = TODO_STATUSES.indexOf(left.status) - TODO_STATUSES.indexOf(right.status);
+    if (byStatus !== 0) return byStatus;
+    if (left.createdAt !== right.createdAt) return left.createdAt - right.createdAt;
+    return left.id < right.id ? -1 : left.id > right.id ? 1 : 0;
+  });
+}
+
+/** Append a task. Throws when the text is bad or the list is full. */
+export function addTodoTask(
+  tasks: readonly TodoTask[],
+  text: string,
+  status?: unknown,
+  now = Date.now(),
+  id = randomUUID().slice(0, 12),
+): TodoTask[] {
+  const task = createTodoTask(text, status, now, id);
+  if (tasks.length >= MAX_TODOS) throw new Error(`the list holds at most ${MAX_TODOS} tasks`);
+  if (tasks.some((existing) => existing.id === task.id)) {
+    throw new Error(`duplicate task id: ${task.id}`);
+  }
+  return [...tasks, task];
+}
+
+/** Change text, status, or both. Throws on an unknown id or bad input. */
+export function updateTodoTask(
+  tasks: readonly TodoTask[],
+  id: string,
+  changes: { text?: string; status?: unknown },
+  now = Date.now(),
+): TodoTask[] {
+  const index = tasks.findIndex((task) => task.id === id);
+  if (index < 0) throw new Error(`unknown task id: ${id}`);
+  const current = tasks[index] as TodoTask;
+  const text = changes.text === undefined ? current.text : normalizeTodoText(changes.text);
+  const status = changes.status === undefined ? current.status : normalizeStatus(changes.status);
+  // A no-op must not bump updatedAt, or reordering by time would drift.
+  if (text === current.text && status === current.status) return [...tasks];
+  const next = [...tasks];
+  next[index] = { ...current, text, status, updatedAt: now };
+  return next;
+}
+
+/** Drop a task. Completed and cancelled ones only leave this way. */
+export function deleteTodoTask(tasks: readonly TodoTask[], id: string): TodoTask[] {
+  const index = tasks.findIndex((task) => task.id === id);
+  if (index < 0) throw new Error(`unknown task id: ${id}`);
+  return tasks.filter((_, at) => at !== index);
+}
+
+function isTodoTask(value: unknown): value is TodoTask {
+  if (!value || typeof value !== "object") return false;
+  const task = value as Record<string, unknown>;
+  return (
+    typeof task.id === "string" && task.id.length > 0 && !CONTROL_CHARACTERS.test(task.id) &&
+    typeof task.text === "string" &&
+    task.text.trim().length > 0 &&
+    task.text.length <= MAX_TODO_TEXT &&
+    !CONTROL_CHARACTERS.test(task.text) &&
+    isTodoStatus(task.status) &&
+    typeof task.createdAt === "number" && Number.isFinite(task.createdAt) &&
+    typeof task.updatedAt === "number" && Number.isFinite(task.updatedAt)
+  );
+}
+
+/**
+ * A run with no session file still needs a working list, so it keeps one in
+ * memory. It dies with the process; there is nothing to persist.
+ */
+let sessionlessTasks: readonly TodoTask[] = [];
+
+/**
+ * Load the persisted list for a session. Never throws: a missing, unreadable
+ * or corrupt file reads as an empty list, and single bad entries are dropped.
+ */
+export function loadTodoTasks(sessionFile: string | undefined): TodoTask[] {
+  if (!sessionFile) return [...sessionlessTasks];
+  try {
+    const file = todoFileFor(sessionFile);
+    if (!existsSync(file)) return [];
+    const parsed: unknown = JSON.parse(readFileSync(file, "utf8"));
+    if (!Array.isArray(parsed)) return [];
+    const seen = new Set<string>();
+    const tasks: TodoTask[] = [];
+    for (const entry of parsed) {
+      if (!isTodoTask(entry)) continue;
+      // A file edited by hand can repeat an id; the first one wins so every
+      // later lookup by id stays unambiguous.
+      if (seen.has(entry.id)) continue;
+      seen.add(entry.id);
+      tasks.push({
+        id: entry.id,
+        text: entry.text,
+        status: entry.status,
+        createdAt: entry.createdAt,
+        updatedAt: entry.updatedAt,
+      });
+    }
+    // File order is arbitrary, so an oversized file drops its lowest-priority
+    // tasks rather than whatever happens to sit past the hundredth line.
+    return tasks.length > MAX_TODOS ? sortTodoTasks(tasks).slice(0, MAX_TODOS) : tasks;
+  } catch {
+    return [];
+  }
+}
+
+/** Write the list atomically. Throws so a caller in a transaction can react. */
+function writeTodoTasks(sessionFile: string | undefined, tasks: readonly TodoTask[]): void {
+  if (!sessionFile) {
+    sessionlessTasks = [...tasks];
+    return;
+  }
+  const file = todoFileFor(sessionFile);
+  // An empty list with no companion file is nothing to record. Writing it
+  // would leave a two-byte "[]" beside every session ever opened.
+  if (tasks.length === 0 && !existsSync(file)) return;
+  // The temp name carries pid and time so two PUM processes on one session
+  // cannot clobber each other's half-written file before the rename.
+  const temporary = `${file}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    writeFileSync(temporary, JSON.stringify(tasks.slice(0, MAX_TODOS), null, 2), "utf8");
+    renameSync(temporary, file);
+  } catch (error) {
+    // The name is never reused, so a leftover temp file would sit there forever.
+    try {
+      rmSync(temporary, { force: true });
+    } catch {
+      // Nothing more to try; the write already failed.
+    }
+    throw error;
+  }
+}
+
+/** Persist the list atomically next to the session. Best effort only. */
+export function saveTodoTasks(
+  sessionFile: string | undefined,
+  tasks: readonly TodoTask[],
+): void {
+  try {
+    writeTodoTasks(sessionFile, tasks);
+  } catch {
+    // A failed todo write never breaks the session.
+  }
+}
+
+function assertStorable(tasks: readonly TodoTask[]): void {
+  if (tasks.length > MAX_TODOS) throw new Error(`the list holds at most ${MAX_TODOS} tasks`);
+  const seen = new Set<string>();
+  for (const task of tasks) {
+    if (!isTodoTask(task)) throw new Error("the list holds an invalid task");
+    if (seen.has(task.id)) throw new Error(`duplicate task id: ${task.id}`);
+    seen.add(task.id);
+  }
+}
+
+/** One promise chain per companion file, so writers queue instead of racing. */
+const chains = new Map<string, Promise<unknown>>();
+
+/**
+ * Serialized read-modify-write. Every mutation reads the file again inside the
+ * chain, so two parallel tool calls cannot each save a stale list and lose the
+ * other's task or push the total past the cap. A mutation that throws leaves
+ * the file exactly as it was, and so does a failed write.
+ *
+ * The chain covers this process only. Two PUM processes on one session file
+ * still race, exactly as they already do for the goal and news companions.
+ */
+export function updateTodoTasks(
+  sessionFile: string | undefined,
+  mutate: (tasks: TodoTask[]) => readonly TodoTask[],
+): Promise<TodoTask[]> {
+  // Sessionless runs share one key, which is also their one in-memory list.
+  const key = sessionFile ? todoFileFor(sessionFile) : "";
+  const previous = chains.get(key) ?? Promise.resolve();
+  const result = previous.then(() => {
+    const tasks = mutate(loadTodoTasks(sessionFile));
+    assertStorable(tasks);
+    const stored = [...tasks];
+    // Not saveTodoTasks: a caller that just added a task must hear about a
+    // failed write, or it reports success over a list that never landed.
+    writeTodoTasks(sessionFile, stored);
+    return stored;
+  });
+  // A rejection must not poison the chain, and the key goes once it drains.
+  const drained: Promise<void> = result.then(() => {}, () => {}).then(() => {
+    if (chains.get(key) === drained) chains.delete(key);
+  });
+  chains.set(key, drained);
+  return result;
+}


### PR DESCRIPTION
The pure state layer for per-agent todo lists (part of #12, #13, #14). No
tools, no UI, no session wiring — the coordinator adds those on top.

## What is here

- `TodoTask`: `id`, `text`, `status`, `createdAt`, `updatedAt`, nothing more.
- `MAX_TODO_TEXT` (500) and `MAX_TODOS` (100). Every status counts toward the
  cap, completed and cancelled included, and the cap holds on load as well as
  on mutation.
- `sortTodoTasks`: the one canonical order both the tools and the popup will
  use — status, then oldest first, then id as the deterministic tie-breaker.
- `<session>.todo.json` beside the session JSONL, built with `node:path` and
  written the way `saveGoal` and `saveNewsItems` write theirs: temp file
  carrying pid and time, then a rename.
- `updateTodoTasks`: a serialized read-modify-write, one promise chain per
  file, so parallel tool calls cannot lose an unrelated task or exceed the cap.

## Rejections

Empty text, NUL bytes and other control characters, unknown statuses, unknown
ids, duplicate ids, and text past the limit. Runs of whitespace fold to one
space first, so a task stays one line in the popup. A rejected mutation leaves
the file exactly as it was.

Loading never throws and never breaks startup: a missing, corrupt or
unreadable file reads as an empty list, and single bad entries are dropped
rather than failing the whole load.

Where this differs from the surrounding companions:

- A failed write propagates out of `updateTodoTasks` instead of being
  swallowed. `saveTodoTasks` stays best-effort, but a tool that just added a
  task must not report success over a list that never landed.
- A rename that fails removes its temp file. The name embeds pid and time, so
  a leftover would sit there forever.
- A run with no session file keeps its list in memory, so add and update still
  compose within the process.

## Verification

`bun test src/todo.test.ts` — 35 pass. `bunx tsc --noEmit` clean.

The two failures in the full `bun test` run (`prompt input layout`,
`subagent transcript UI`) are pre-existing; they reproduce with these files
stashed out and neither imports `todo`.

## Follow-up for the coordinator

`COMPANION_SUFFIXES` in `src/session-history-metadata.ts` lists `.news.json`,
`.stats.json` and `.tool-groups.json`, so `sweepOrphanedCompanions` will leave
`<session>.todo.json` behind when a session JSONL is deleted. `.goal.json` is
missing from the same list already. That file is outside this unit's ownership,
so it is untouched here.
