### PR TITLE
Add the worktree start flow

### DIFF
--- a/src/worktree-start.test.ts
+++ b/src/worktree-start.test.ts
@@ -1,0 +1,138 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { canonicalPathIdentity, isPathInside, pathsHaveSameIdentity } from "./platform";
+import {
+  UNCOMMITTED_CHANGES_NOTICE,
+  startWorktree,
+  worktreeStartMessage,
+} from "./worktree-start";
+
+const root = mkdtempSync(join(tmpdir(), "pum-worktree-start-test-"));
+const git = (cwd: string, ...args: string[]) =>
+  execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+
+afterAll(() => rmSync(root, {
+  recursive: true,
+  force: true,
+  maxRetries: process.platform === "win32" ? 10 : 0,
+  retryDelay: 100,
+}));
+
+const setup = (name: string) => {
+  const repo = mkdtempSync(join(root, `${name}-`));
+  git(repo, "init", "-b", "main");
+  git(repo, "config", "user.email", "pum@example.test");
+  git(repo, "config", "user.name", "PUM Test");
+  writeFileSync(join(repo, "file.txt"), "main\n");
+  git(repo, "add", "file.txt");
+  git(repo, "commit", "-m", "initial");
+  return repo;
+};
+
+const generatedName = /^[a-z]+-[a-z]+-[0-9a-f]{4}$/;
+
+describe("starting a worktree", () => {
+  test("creates an auto-named worktree inside the managed directory", async () => {
+    const repo = setup("happy");
+    const start = await startWorktree(repo);
+
+    expect(start.worktree.name).toMatch(generatedName);
+    expect(start.worktree.branch).toBe(`pum/${start.worktree.name}`);
+    expect(start.worktree.baseBranch).toBe("main");
+    expect(start.worktree.baseCommit).toBe(git(repo, "rev-parse", "HEAD"));
+    expect(await pathsHaveSameIdentity(start.sourceRoot, repo)).toBe(true);
+    expect(isPathInside(
+      await canonicalPathIdentity(join(repo, ".pum", "worktrees")),
+      await canonicalPathIdentity(start.worktree.path),
+    )).toBe(true);
+    expect(git(start.worktree.path, "rev-parse", "--abbrev-ref", "HEAD"))
+      .toBe(start.worktree.branch);
+  }, 30_000);
+
+  test("names the worktree itself and never after the directory", async () => {
+    const repo = setup("naming");
+    const first = await startWorktree(repo);
+    const second = await startWorktree(repo);
+
+    expect(second.worktree.name).not.toBe(first.worktree.name);
+    for (const start of [first, second]) {
+      expect(start.worktree.name).toMatch(generatedName);
+      expect(start.worktree.name).not.toContain(basename(repo));
+    }
+  }, 30_000);
+
+  test("resolves a relative directory against the given working directory", async () => {
+    const repo = setup("relative");
+    const start = await startWorktree(basename(repo), root);
+    expect(await pathsHaveSameIdentity(start.sourceRoot, repo)).toBe(true);
+  }, 30_000);
+
+  test("starts from a dirty source tree without copying the changes", async () => {
+    const repo = setup("dirty");
+    writeFileSync(join(repo, "file.txt"), "edited but not committed\n");
+    writeFileSync(join(repo, "untracked.txt"), "untracked\n");
+
+    const start = await startWorktree(repo);
+
+    expect(readFileSync(join(start.worktree.path, "file.txt"), "utf8"))
+      .toContain("main");
+    expect(() => readFileSync(join(start.worktree.path, "untracked.txt"), "utf8")).toThrow();
+    // The source keeps its own changes.
+    expect(git(repo, "status", "--porcelain")).toContain("file.txt");
+  }, 30_000);
+});
+
+describe("rejected starts", () => {
+  test("rejects a file", async () => {
+    const repo = setup("a-file");
+    await expect(startWorktree(join(repo, "file.txt")))
+      .rejects.toThrow("it is a file, not a directory");
+  }, 30_000);
+
+  test("rejects a missing directory", async () => {
+    const repo = setup("missing");
+    await expect(startWorktree(join(repo, "absent")))
+      .rejects.toThrow("the directory does not exist");
+  }, 30_000);
+
+  test("rejects a directory outside any repository", async () => {
+    const plain = mkdtempSync(join(root, "not-a-repo-"));
+    await expect(startWorktree(plain))
+      .rejects.toThrow("it is not inside a git repository");
+  }, 30_000);
+
+  test("rejects a detached HEAD", async () => {
+    const repo = setup("detached");
+    git(repo, "checkout", "--detach", "HEAD");
+    await expect(startWorktree(repo))
+      .rejects.toThrow("HEAD is not on a branch");
+  }, 30_000);
+
+  test("rejects a repository without a first commit", async () => {
+    const repo = mkdtempSync(join(root, "unborn-"));
+    git(repo, "init", "-b", "main");
+    await expect(startWorktree(repo)).rejects.toThrow("branch main has no commits yet");
+  }, 30_000);
+});
+
+describe("start message", () => {
+  test("names both identities and warns about uncommitted changes", () => {
+    const message = worktreeStartMessage({
+      sourceRoot: "/repo",
+      worktree: {
+        name: "amber-owl-1234",
+        path: "/repo/.pum/worktrees/amber-owl-1234",
+        branch: "pum/amber-owl-1234",
+        baseBranch: "main",
+        baseCommit: "0123456789abcdef",
+      },
+    });
+    expect(message).toContain("pum/amber-owl-1234");
+    expect(message).toContain("/repo/.pum/worktrees/amber-owl-1234");
+    expect(message).toContain("/repo (main at 0123456)");
+    expect(message).toContain(UNCOMMITTED_CHANGES_NOTICE);
+  });
+});

--- a/src/worktree-start.ts
+++ b/src/worktree-start.ts
@@ -1,0 +1,174 @@
+import { execFile } from "node:child_process";
+import { stat } from "node:fs/promises";
+import { resolve } from "node:path";
+import { promisify } from "node:util";
+import { canonicalPathIdentity, isPathInside } from "./platform";
+import { createWorktree, type WorktreeRecord } from "./worktree";
+
+const execFileAsync = promisify(execFile);
+
+export type WorktreeStart = {
+  /** The generated worktree; this becomes the active project. */
+  worktree: WorktreeRecord;
+  /**
+   * Canonical identity of the repository the worktree came from. The caller
+   * grants it as an extra writable root, so it is the resolved path — links
+   * followed, and on Windows case-folded — not the spelling the user typed.
+   */
+  sourceRoot: string;
+};
+
+/**
+ * `git worktree add` checks out a commit, so anything still unstaged or
+ * uncommitted stays in the source tree. Repeat this wherever the flow reports
+ * success: someone who edits a file, runs `pum worktree`, and lands in a tree
+ * without those edits reads it as lost work.
+ */
+export const UNCOMMITTED_CHANGES_NOTICE =
+  "Uncommitted changes in the source repository are not copied; "
+    + "the worktree starts from the current commit.";
+
+async function git(cwd: string, args: string[]): Promise<string> {
+  // execFile, never a shell: a repository path can hold quotes, spaces, and
+  // shell metacharacters.
+  const result = await execFileAsync("git", args, {
+    cwd,
+    encoding: "utf8",
+    maxBuffer: 4 * 1024 * 1024,
+  });
+  // Only the line ending goes: a directory name may end in a space, and
+  // trimming it turns a valid repository root into a path that does not exist.
+  return result.stdout.replace(/\r?\n$/, "");
+}
+
+async function assertDirectory(path: string): Promise<void> {
+  let entry;
+  try {
+    // stat follows symlinks and junctions, so a linked project directory is
+    // accepted and judged by what it points at.
+    entry = await stat(path);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "ENOTDIR") {
+      throw new Error(`Cannot start a worktree in ${path}: the directory does not exist`);
+    }
+    throw new Error(`Cannot start a worktree in ${path}: ${(error as Error).message}`);
+  }
+  if (!entry.isDirectory()) {
+    throw new Error(`Cannot start a worktree in ${path}: it is a file, not a directory`);
+  }
+}
+
+async function repositoryRoot(directory: string): Promise<string> {
+  let top: string;
+  try {
+    top = await git(directory, ["rev-parse", "--show-toplevel"]);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error("Cannot start a worktree: git is not installed or not on PATH");
+    }
+    throw new Error(`Cannot start a worktree in ${directory}: it is not inside a git repository`);
+  }
+  if (!top) {
+    throw new Error(`Cannot start a worktree in ${directory}: it is not inside a git repository`);
+  }
+  try {
+    return await canonicalPathIdentity(top);
+  } catch (error) {
+    throw new Error(`Cannot start a worktree: repository root ${top} does not resolve: `
+      + (error as Error).message);
+  }
+}
+
+/**
+ * Create an auto-named worktree of the repository holding `directory` and
+ * report both identities the caller needs: the new worktree to run in, and the
+ * source repository to keep writable.
+ *
+ * The name is always generated. A caller- or model-supplied name never reaches
+ * `createWorktree`, so a crafted name cannot steer the branch or the path.
+ *
+ * A dirty source tree is fine — see UNCOMMITTED_CHANGES_NOTICE for what that
+ * costs.
+ *
+ * `cwd` resolves a relative `directory` and exists so tests need not chdir.
+ */
+export async function startWorktree(
+  directory?: string,
+  cwd: string = process.cwd(),
+): Promise<WorktreeStart> {
+  const requested = resolve(cwd, directory ?? ".");
+  await assertDirectory(requested);
+  const sourceRoot = await repositoryRoot(requested);
+
+  // createWorktree rejects a detached HEAD too, but only after it has resolved
+  // the root and read HEAD. Check first so the failure names this flow and this
+  // directory instead of the generic creation error. A paused rebase or bisect
+  // also leaves no current branch, and there the fix is to finish it, not to
+  // check one out.
+  const branch = await git(sourceRoot, ["branch", "--show-current"]);
+  if (!branch) {
+    throw new Error(
+      `Cannot start a worktree in ${sourceRoot}: HEAD is not on a branch. `
+        + "Check out a branch, or finish an in-progress rebase or bisect, first.",
+    );
+  }
+  // A branch can exist before its first commit, and there is no commit to base
+  // the worktree on. Say that, rather than letting git's raw "unknown revision
+  // HEAD" out.
+  const unborn = await git(sourceRoot, ["rev-parse", "--verify", "--quiet", "HEAD"])
+    .then(() => false)
+    .catch(() => true);
+  if (unborn) {
+    throw new Error(
+      `Cannot start a worktree in ${sourceRoot}: branch ${branch} has no commits yet`,
+    );
+  }
+
+  let worktree: WorktreeRecord;
+  try {
+    worktree = await createWorktree(sourceRoot);
+  } catch (error) {
+    throw new Error(`Cannot start a worktree in ${sourceRoot}: ${(error as Error).message}`);
+  }
+
+  try {
+    await assertManaged(sourceRoot, worktree);
+  } catch (error) {
+    // The worktree exists on disk but sits outside the managed directory, so
+    // removeWorktree would refuse it anyway. Leave it and name it: deleting a
+    // checkout we cannot vouch for risks taking work with it.
+    throw new Error(
+      `${(error as Error).message}. Worktree ${worktree.path} on branch ${worktree.branch} was kept; `
+        + "remove it by hand once you have checked it.",
+    );
+  }
+
+  return { worktree, sourceRoot };
+}
+
+/**
+ * Confirm the new checkout really lives under this repository's managed
+ * directory. createWorktree compares realpath spellings; identities fold the
+ * case and short-path spellings Windows also answers with, so a valid root is
+ * not rejected and a foreign one is not authorized.
+ */
+async function assertManaged(sourceRoot: string, worktree: WorktreeRecord): Promise<void> {
+  const [managed, created] = await Promise.all([
+    canonicalPathIdentity(resolve(sourceRoot, ".pum", "worktrees")),
+    canonicalPathIdentity(worktree.path),
+  ]);
+  if (!isPathInside(managed, created)) {
+    throw new Error(`Created worktree resolves outside ${managed}`);
+  }
+}
+
+export function worktreeStartMessage(start: WorktreeStart): string {
+  const { worktree, sourceRoot } = start;
+  return [
+    `Started worktree ${worktree.name} on branch ${worktree.branch}`,
+    `  path:   ${worktree.path}`,
+    `  source: ${sourceRoot} (${worktree.baseBranch} at ${worktree.baseCommit.slice(0, 7)})`,
+    `  ${UNCOMMITTED_CHANGES_NOTICE}`,
+  ].join("\n");
+}


### PR DESCRIPTION
Part of #13. Adds the creation flow behind `pum worktree [directory]` / `pum w [directory]` as a pure, testable function. The CLI parser and the launch dispatch are separate units and are not touched here.

`startWorktree(directory?, cwd?)` returns both identities the caller needs:

- `worktree` — the created `WorktreeRecord`, the new active project.
- `sourceRoot` — the canonical source repository root, which the caller authorizes as an extra writable root.

What it does:

- Resolves the directory (default: the current one) and requires it to exist and be a directory.
- Finds the repository root and requires an attached branch with at least one commit.
- Generates the name with `randomWorktreeName()`. No caller- or model-supplied name reaches `createWorktree`, so a crafted name cannot steer the branch or the path.
- Reuses `createWorktree`, which bases branch `pum/<name>` at `<root>/.pum/worktrees/<name>` on the current `HEAD` commit.
- Re-checks containment through `canonicalPathIdentity` and `isPathInside`, so a linked, junctioned, case-varying, or 8.3 short-path spelling neither rejects a valid root nor authorizes a foreign one.

Distinct rejections for: a file, a missing path, a directory outside any repository, a detached HEAD (or a paused rebase/bisect), a branch with no commits, and a missing `git` binary.

A dirty source tree is allowed. Creation checks out a commit, so uncommitted changes are not copied; `UNCOMMITTED_CHANGES_NOTICE` and `worktreeStartMessage()` say so in the text the CLI shows.

If the worktree is created and a later check fails, it is kept and named rather than deleted — a checkout we cannot vouch for may still hold work.

Tests: happy path with containment under `.pum/worktrees`, auto-generated naming, relative directory resolution, a dirty source repository, and each rejection. Real `git init` under `mkdtempSync(tmpdir())`, as in `src/worktree.test.ts`.

`bun test`: 1102 pass. The two failures on this branch (`prompt input layout`, `subagent transcript UI`) are pre-existing status-bar assertions that break on any long checkout branch name; they do not touch this code. `bunx tsc --noEmit` is clean.