### PR TITLE
Sweep the goal and todo sidecars too

### DIFF
--- a/src/session-history-metadata.test.ts
+++ b/src/session-history-metadata.test.ts
@@ -9,6 +9,7 @@ import {
   knownTokensFromUsage,
   SessionHistoryIndex,
   sortSessionHistory,
+  COMPANION_SUFFIXES,
   sweepOrphanedCompanions,
   type SessionHistoryItem,
 } from "./session-history-metadata";
@@ -176,7 +177,9 @@ describe("orphaned session companions", () => {
   test("removes companions of deleted sessions and keeps live ones", async () => {
     const root = await tempRoot();
     await writeFile(join(root, "live.jsonl"), "");
-    for (const suffix of [".news.json", ".stats.json", ".tool-groups.json"]) {
+    // Drive this from the constant, so a companion added later cannot quietly
+    // escape the sweep the way .goal.json did.
+    for (const suffix of COMPANION_SUFFIXES) {
       await writeFile(join(root, `live${suffix}`), "{}");
       await writeFile(join(root, `gone${suffix}`), "{}");
     }
@@ -184,14 +187,12 @@ describe("orphaned session companions", () => {
 
     const removed = await sweepOrphanedCompanions(root);
 
-    expect(removed.sort()).toEqual(["gone.news.json", "gone.stats.json", "gone.tool-groups.json"]);
+    expect(removed.sort()).toEqual(COMPANION_SUFFIXES.map((s) => `gone${s}`).sort());
     expect((await readdir(root)).sort()).toEqual([
       "live.jsonl",
-      "live.news.json",
-      "live.stats.json",
-      "live.tool-groups.json",
+      ...COMPANION_SUFFIXES.map((s) => `live${s}`),
       "notes.json",
-    ]);
+    ].sort());
   });
 
   test("stays silent when the directory cannot be read", async () => {

--- a/src/session-history-metadata.ts
+++ b/src/session-history-metadata.ts
@@ -31,7 +31,17 @@ type CacheEntry = {
 };
 
 /** Files written next to `<session>.jsonl` that live and die with it. */
-const COMPANION_SUFFIXES = [".news.json", ".stats.json", ".tool-groups.json"] as const;
+/**
+ * Sidecars a session owns. A suffix missing here leaks one file per deleted
+ * session, so every new companion file must be added.
+ */
+export const COMPANION_SUFFIXES = [
+  ".news.json",
+  ".stats.json",
+  ".tool-groups.json",
+  ".goal.json",
+  ".todo.json",
+] as const;
 
 const DEFAULT_MAX_CACHE_ENTRIES = 256;
 const DEFAULT_CONCURRENCY = 8;


### PR DESCRIPTION
`COMPANION_SUFFIXES` lists the sidecars `sweepOrphanedCompanions` cleans up when a session JSONL is gone. It never learned about `.goal.json`, so every session deleted since goals shipped has left an orphaned goal file in the sessions directory. `.todo.json` (PR #21) would have been the next one.

The test kept its own hand-written copy of the list, which is why the drift went unnoticed. It now iterates the exported constant, so adding a companion file without sweeping it fails the test.