### PR TITLE
Give the model five tools for its todo list

### DIFF
--- a/src/todo-tools.test.ts
+++ b/src/todo-tools.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { MAX_TODOS, todoFileFor, type TodoTask } from "./todo";
+import { MAX_TODO_TEXT, MAX_TODOS, TODO_STATUSES, todoFileFor, type TodoTask } from "./todo";
 import { TODO_TOOL_NAMES, TodoToolsController } from "./todo-tools";
 
 const directories: string[] = [];
@@ -10,9 +10,19 @@ const directories: string[] = [];
 type Tool = {
   name: string;
   description: string;
+  executionMode: string;
   parameters: any;
   execute: (id: string, params: any) => Promise<{ content: { text: string }[]; details: any }>;
 };
+
+function register(controller: TodoToolsController) {
+  const tools = new Map<string, Tool>();
+  controller.registerTool({ registerTool(tool: any) { tools.set(tool.name, tool); } } as any);
+  return {
+    tools,
+    call: (name: string, params: any = {}) => (tools.get(name) as Tool).execute("call", params),
+  };
+}
 
 function fixture(audience: "main" | "subagent" = "main") {
   const directory = mkdtempSync(join(tmpdir(), "pum-todo-tools-"));
@@ -20,10 +30,13 @@ function fixture(audience: "main" | "subagent" = "main") {
   const sessionFile = join(directory, "session.jsonl");
   const controller = new TodoToolsController(audience);
   controller.load(sessionFile);
-  const tools = new Map<string, Tool>();
-  controller.registerTool({ registerTool(tool: any) { tools.set(tool.name, tool); } } as any);
-  const call = (name: string, params: any = {}) => (tools.get(name) as Tool).execute("call", params);
-  return { controller, directory, sessionFile, todoFile: todoFileFor(sessionFile), tools, call };
+  return {
+    controller,
+    directory,
+    sessionFile,
+    todoFile: todoFileFor(sessionFile),
+    ...register(controller),
+  };
 }
 
 afterEach(() => {
@@ -38,14 +51,35 @@ describe("todo tools", () => {
 
   test("no tool takes an owner, agent, session or path", () => {
     const { tools } = fixture();
-    for (const tool of tools.values()) {
-      expect(tool.parameters.additionalProperties).toBe(false);
-      const keys = Object.keys(tool.parameters.properties ?? {});
-      expect(keys.every((key) => ["id", "text", "status"].includes(key))).toBe(true);
-      for (const key of keys) {
+    const expected: Record<string, { properties: string[]; required: string[] }> = {
+      todo_list: { properties: ["status"], required: [] },
+      todo_add: { properties: ["text", "status"], required: ["text"] },
+      todo_update: { properties: ["id", "text", "status"], required: ["id"] },
+      todo_complete: { properties: ["id"], required: ["id"] },
+      todo_delete: { properties: ["id"], required: ["id"] },
+    };
+    for (const [name, shape] of Object.entries(expected)) {
+      const schema = (tools.get(name) as Tool).parameters;
+      expect(schema.additionalProperties).toBe(false);
+      expect(Object.keys(schema.properties).sort()).toEqual([...shape.properties].sort());
+      expect([...(schema.required ?? [])].sort()).toEqual([...shape.required].sort());
+      for (const key of Object.keys(schema.properties)) {
         expect(/agent|session|owner|path|file|dir/i.test(key)).toBe(false);
       }
     }
+  });
+
+  test("the schemas bound text and status", () => {
+    const { tools } = fixture();
+    const add = (tools.get("todo_add") as Tool).parameters;
+    expect(add.properties.text.minLength).toBe(1);
+    expect(add.properties.text.maxLength).toBe(MAX_TODO_TEXT);
+    expect(add.properties.status.anyOf.map((option: any) => option.const)).toEqual([...TODO_STATUSES]);
+  });
+
+  test("every tool runs sequentially, which is what makes a plain read safe", () => {
+    const { tools } = fixture();
+    for (const tool of tools.values()) expect(tool.executionMode).toBe("sequential");
   });
 
   test("todo_add defaults to pending and returns the created task", async () => {
@@ -60,6 +94,29 @@ describe("todo tools", () => {
     expect(task.status).toBe("pending");
     expect(task.createdAt).toBe(task.updatedAt);
     expect(result.content[0]!.text).toContain(task.id);
+  });
+
+  test("todo_add reports the task it created, not whichever one sorts last", async () => {
+    const { call } = fixture();
+    await call("todo_add", { text: "sorts first", status: "active" });
+    await call("todo_add", { text: "sorts last", status: "cancelled" });
+
+    const added = await call("todo_add", { text: "the new one" });
+    expect(added.details.task.text).toBe("the new one");
+    const listed = (await call("todo_list")).details.tasks as TodoTask[];
+    expect(listed.find((task) => task.id === added.details.task.id)?.text).toBe("the new one");
+  });
+
+  test("todo_add refuses text the state layer will not store", async () => {
+    const { call, todoFile } = fixture();
+    await expect(call("todo_add", { text: "x".repeat(MAX_TODO_TEXT + 1) })).rejects.toThrow(
+      `a task is at most ${MAX_TODO_TEXT} characters`,
+    );
+    await expect(call("todo_add", { text: "repaint \u001b[2J" })).rejects.toThrow(
+      "task text cannot hold control characters",
+    );
+    await expect(call("todo_add", { text: "   " })).rejects.toThrow("a task needs text");
+    expect(existsSync(todoFile)).toBe(false);
   });
 
   test("todo_add takes a status and persists it", async () => {
@@ -169,13 +226,26 @@ describe("todo tools", () => {
 
     const first = await call("todo_complete", { id: created.id });
     expect(first.details.task.status).toBe("completed");
+    expect(first.details.changed).toBe(true);
     await Bun.sleep(2);
 
     const second = await call("todo_complete", { id: created.id });
     expect(second.details.task.status).toBe("completed");
-    // A repeat is a no-op, so nothing about the task moves.
+    // A repeat is a no-op, so nothing about the task moves and it says so.
+    expect(second.details.changed).toBe(false);
     expect(second.details.task.updatedAt).toBe(first.details.task.updatedAt);
+    expect(second.content[0]!.text).toContain("was already completed");
     expect((await call("todo_list")).details.count).toBe(1);
+  });
+
+  test("todo_update reports a change that changes nothing as such", async () => {
+    const { call } = fixture();
+    const created = (await call("todo_add", { text: "same text" })).details.task as TodoTask;
+
+    const again = await call("todo_update", { id: created.id, text: "same text" });
+    expect(again.details.changed).toBe(false);
+    expect(again.details.task.updatedAt).toBe(created.updatedAt);
+    expect(again.content[0]!.text).toContain("nothing changed");
   });
 
   test("todo_delete removes a task of any status and reports its identity", async () => {
@@ -223,7 +293,7 @@ describe("todo tools", () => {
     const before = readFileSync(todoFile, "utf8");
 
     await expect(call("todo_add", { text: "one too many" })).rejects.toThrow(
-      `the list holds at most ${MAX_TODOS} tasks`,
+      `the list holds at most ${MAX_TODOS} tasks. Complete or delete one before adding another.`,
     );
     expect(readFileSync(todoFile, "utf8")).toBe(before);
 
@@ -283,6 +353,53 @@ describe("todo tools", () => {
     controller.load(later);
     expect(controller.sessionFile).toBe(later);
     expect(controller.list()).toHaveLength(0);
+  });
+
+  test("a constructed session file needs no load", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "pum-todo-tools-"));
+    directories.push(directory);
+    const sessionFile = join(directory, "session.jsonl");
+    const controller = new TodoToolsController("subagent", sessionFile);
+
+    expect(controller.sessionFile).toBe(sessionFile);
+    await register(controller).call("todo_add", { text: "bound at birth" });
+    expect(existsSync(todoFileFor(sessionFile))).toBe(true);
+  });
+
+  test("no session file unbinds, so a reused controller never writes to the old one", async () => {
+    const { controller, todoFile } = fixture();
+    await controller.add("first run");
+
+    controller.load(undefined);
+    expect(controller.sessionFile).toBeUndefined();
+    controller.load(null);
+    expect(controller.sessionFile).toBeUndefined();
+    controller.load("");
+    expect(controller.sessionFile).toBeUndefined();
+
+    const before = readFileSync(todoFile, "utf8");
+    await controller.add("second run");
+    expect(readFileSync(todoFile, "utf8")).toBe(before);
+    // Clean up the process-wide sessionless list this test just wrote to.
+    for (const task of controller.list()) await controller.delete(task.id);
+  });
+
+  test("a child with no session file gets no list rather than the main one", async () => {
+    const main = new TodoToolsController("main");
+    const child = new TodoToolsController("subagent");
+    const message = "this agent has no todo list";
+
+    const mine = await main.add("main only");
+    try {
+      expect(main.list().some((task) => task.id === mine.id)).toBe(true);
+      expect(() => child.list()).toThrow(message);
+      await expect(child.add("child task")).rejects.toThrow(message);
+      await expect(child.complete(mine.id)).rejects.toThrow(message);
+      await expect(child.update(mine.id, { status: "cancelled" })).rejects.toThrow(message);
+      await expect(child.delete(mine.id)).rejects.toThrow(message);
+    } finally {
+      await main.delete(mine.id);
+    }
   });
 
   test("the extension name carries the audience", () => {

--- a/src/todo-tools.test.ts
+++ b/src/todo-tools.test.ts
@@ -1,0 +1,292 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { MAX_TODOS, todoFileFor, type TodoTask } from "./todo";
+import { TODO_TOOL_NAMES, TodoToolsController } from "./todo-tools";
+
+const directories: string[] = [];
+
+type Tool = {
+  name: string;
+  description: string;
+  parameters: any;
+  execute: (id: string, params: any) => Promise<{ content: { text: string }[]; details: any }>;
+};
+
+function fixture(audience: "main" | "subagent" = "main") {
+  const directory = mkdtempSync(join(tmpdir(), "pum-todo-tools-"));
+  directories.push(directory);
+  const sessionFile = join(directory, "session.jsonl");
+  const controller = new TodoToolsController(audience);
+  controller.load(sessionFile);
+  const tools = new Map<string, Tool>();
+  controller.registerTool({ registerTool(tool: any) { tools.set(tool.name, tool); } } as any);
+  const call = (name: string, params: any = {}) => (tools.get(name) as Tool).execute("call", params);
+  return { controller, directory, sessionFile, todoFile: todoFileFor(sessionFile), tools, call };
+}
+
+afterEach(() => {
+  for (const directory of directories.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+describe("todo tools", () => {
+  test("registers exactly the five todo tools", () => {
+    const { tools } = fixture();
+    expect([...tools.keys()].sort()).toEqual([...TODO_TOOL_NAMES].sort());
+  });
+
+  test("no tool takes an owner, agent, session or path", () => {
+    const { tools } = fixture();
+    for (const tool of tools.values()) {
+      expect(tool.parameters.additionalProperties).toBe(false);
+      const keys = Object.keys(tool.parameters.properties ?? {});
+      expect(keys.every((key) => ["id", "text", "status"].includes(key))).toBe(true);
+      for (const key of keys) {
+        expect(/agent|session|owner|path|file|dir/i.test(key)).toBe(false);
+      }
+    }
+  });
+
+  test("todo_add defaults to pending and returns the created task", async () => {
+    const { call } = fixture();
+    const result = await call("todo_add", { text: "  write   the parser  " });
+    const task = result.details.task as TodoTask;
+
+    expect(task.id).toBeString();
+    expect(task.id.length).toBeGreaterThan(0);
+    // Runs of whitespace collapse, so the popup keeps one line per task.
+    expect(task.text).toBe("write the parser");
+    expect(task.status).toBe("pending");
+    expect(task.createdAt).toBe(task.updatedAt);
+    expect(result.content[0]!.text).toContain(task.id);
+  });
+
+  test("todo_add takes a status and persists it", async () => {
+    const { call, todoFile } = fixture();
+    const added = await call("todo_add", { text: "review the diff", status: "active" });
+
+    expect(added.details.task.status).toBe("active");
+    const stored = JSON.parse(readFileSync(todoFile, "utf8")) as TodoTask[];
+    expect(stored).toHaveLength(1);
+    expect(stored[0]!.status).toBe("active");
+  });
+
+  test("todo_list reports ids, text, status and timestamps in canonical order", async () => {
+    const { call } = fixture();
+    await call("todo_add", { text: "pending one" });
+    await call("todo_add", { text: "blocked one", status: "blocked" });
+    const active = await call("todo_add", { text: "active one", status: "active" });
+
+    const listed = await call("todo_list");
+    const tasks = listed.details.tasks as TodoTask[];
+    expect(tasks.map((task) => task.text)).toEqual(["active one", "pending one", "blocked one"]);
+    for (const task of tasks) {
+      expect(task.id).toBeString();
+      expect(task.createdAt).toBeNumber();
+      expect(task.updatedAt).toBeNumber();
+    }
+    const text = listed.content[0]!.text;
+    expect(text).toContain("3 tasks:");
+    expect(text).toContain(active.details.task.id);
+    expect(text).toContain("[active] active one");
+    expect(text).toContain(new Date(tasks[0]!.createdAt).toISOString());
+  });
+
+  test("todo_list filters by status", async () => {
+    const { call } = fixture();
+    await call("todo_add", { text: "one" });
+    await call("todo_add", { text: "two", status: "blocked" });
+
+    const blocked = await call("todo_list", { status: "blocked" });
+    expect(blocked.details.count).toBe(1);
+    expect((blocked.details.tasks as TodoTask[])[0]!.text).toBe("two");
+
+    const cancelled = await call("todo_list", { status: "cancelled" });
+    expect(cancelled.details.count).toBe(0);
+    expect(cancelled.content[0]!.text).toBe("No cancelled tasks.");
+  });
+
+  test("todo_list on an empty list reads as empty and writes nothing", async () => {
+    const { call, todoFile } = fixture();
+    const listed = await call("todo_list");
+    expect(listed.details.count).toBe(0);
+    expect(listed.content[0]!.text).toBe("No tasks.");
+    expect(existsSync(todoFile)).toBe(false);
+  });
+
+  test("todo_update keeps createdAt and moves updatedAt", async () => {
+    const { call } = fixture();
+    const added = await call("todo_add", { text: "first text" });
+    const created = added.details.task as TodoTask;
+    await Bun.sleep(2);
+
+    const updated = await call("todo_update", { id: created.id, text: "second text", status: "active" });
+    const task = updated.details.task as TodoTask;
+    expect(task.id).toBe(created.id);
+    expect(task.text).toBe("second text");
+    expect(task.status).toBe("active");
+    expect(task.createdAt).toBe(created.createdAt);
+    expect(task.updatedAt).toBeGreaterThan(created.updatedAt);
+  });
+
+  test("todo_update accepts text alone and status alone", async () => {
+    const { call } = fixture();
+    const created = (await call("todo_add", { text: "one" })).details.task as TodoTask;
+
+    const textOnly = await call("todo_update", { id: created.id, text: "one renamed" });
+    expect(textOnly.details.task.status).toBe("pending");
+    expect(textOnly.details.task.text).toBe("one renamed");
+
+    const statusOnly = await call("todo_update", { id: created.id, status: "blocked" });
+    expect(statusOnly.details.task.text).toBe("one renamed");
+    expect(statusOnly.details.task.status).toBe("blocked");
+  });
+
+  test("todo_update demands at least one change", async () => {
+    const { call, todoFile } = fixture();
+    const created = (await call("todo_add", { text: "one" })).details.task as TodoTask;
+    const before = readFileSync(todoFile, "utf8");
+
+    await expect(call("todo_update", { id: created.id })).rejects.toThrow(
+      "nothing to change: pass text, status, or both",
+    );
+    expect(readFileSync(todoFile, "utf8")).toBe(before);
+  });
+
+  test("todo_update refuses bad text and leaves the file alone", async () => {
+    const { call, todoFile } = fixture();
+    const created = (await call("todo_add", { text: "one" })).details.task as TodoTask;
+    const before = readFileSync(todoFile, "utf8");
+
+    await expect(call("todo_update", { id: created.id, text: "   " })).rejects.toThrow("a task needs text");
+    expect(readFileSync(todoFile, "utf8")).toBe(before);
+  });
+
+  test("todo_complete is idempotent", async () => {
+    const { call } = fixture();
+    const created = (await call("todo_add", { text: "ship it" })).details.task as TodoTask;
+
+    const first = await call("todo_complete", { id: created.id });
+    expect(first.details.task.status).toBe("completed");
+    await Bun.sleep(2);
+
+    const second = await call("todo_complete", { id: created.id });
+    expect(second.details.task.status).toBe("completed");
+    // A repeat is a no-op, so nothing about the task moves.
+    expect(second.details.task.updatedAt).toBe(first.details.task.updatedAt);
+    expect((await call("todo_list")).details.count).toBe(1);
+  });
+
+  test("todo_delete removes a task of any status and reports its identity", async () => {
+    const { call } = fixture();
+    const created = (await call("todo_add", { text: "drop me" })).details.task as TodoTask;
+    await call("todo_complete", { id: created.id });
+
+    const deleted = await call("todo_delete", { id: created.id });
+    expect(deleted.details.task.id).toBe(created.id);
+    expect(deleted.details.task.text).toBe("drop me");
+    expect(deleted.details.task.status).toBe("completed");
+    expect((await call("todo_list")).details.count).toBe(0);
+  });
+
+  test("an unknown id is refused with a recovery hint and changes nothing", async () => {
+    const { call, todoFile } = fixture();
+    await call("todo_add", { text: "keep me" });
+    const before = readFileSync(todoFile, "utf8");
+
+    for (const name of ["todo_update", "todo_complete", "todo_delete"]) {
+      const params = name === "todo_update" ? { id: "nope", status: "active" } : { id: "nope" };
+      await expect(call(name, params)).rejects.toThrow(
+        "unknown task id: nope. Call todo_list for the ids that still exist.",
+      );
+    }
+    expect(readFileSync(todoFile, "utf8")).toBe(before);
+  });
+
+  test("a stale id is refused after the task is deleted", async () => {
+    const { call, todoFile } = fixture();
+    const created = (await call("todo_add", { text: "temporary" })).details.task as TodoTask;
+    await call("todo_delete", { id: created.id });
+    const before = readFileSync(todoFile, "utf8");
+
+    await expect(call("todo_complete", { id: created.id })).rejects.toThrow("unknown task id");
+    expect(readFileSync(todoFile, "utf8")).toBe(before);
+  });
+
+  test("todo_add refuses the task past the cap", async () => {
+    const { call, todoFile } = fixture();
+    for (let index = 0; index < MAX_TODOS; index += 1) {
+      await call("todo_add", { text: `task ${index}` });
+    }
+    expect((await call("todo_list")).details.count).toBe(MAX_TODOS);
+    const before = readFileSync(todoFile, "utf8");
+
+    await expect(call("todo_add", { text: "one too many" })).rejects.toThrow(
+      `the list holds at most ${MAX_TODOS} tasks`,
+    );
+    expect(readFileSync(todoFile, "utf8")).toBe(before);
+
+    // Room reopens the moment a task leaves.
+    const first = (await call("todo_list")).details.tasks[0] as TodoTask;
+    await call("todo_delete", { id: first.id });
+    await call("todo_add", { text: "now it fits" });
+    expect((await call("todo_list")).details.count).toBe(MAX_TODOS);
+  });
+
+  test("parallel adds all land", async () => {
+    const { call } = fixture();
+    await Promise.all(
+      Array.from({ length: 12 }, (_, index) => call("todo_add", { text: `parallel ${index}` })),
+    );
+    const listed = await call("todo_list");
+    expect(listed.details.count).toBe(12);
+    expect(new Set((listed.details.tasks as TodoTask[]).map((task) => task.id)).size).toBe(12);
+  });
+
+  test("two sessions keep separate lists", async () => {
+    const main = fixture("main");
+    const child = fixture("subagent");
+
+    const mine = (await main.call("todo_add", { text: "main work" })).details.task as TodoTask;
+    await child.call("todo_add", { text: "child work" });
+
+    expect((await main.call("todo_list")).details.tasks.map((task: TodoTask) => task.text)).toEqual(["main work"]);
+    expect((await child.call("todo_list")).details.tasks.map((task: TodoTask) => task.text)).toEqual(["child work"]);
+
+    // A child cannot reach the main list even holding a main id.
+    await expect(child.call("todo_delete", { id: mine.id })).rejects.toThrow("unknown task id");
+    expect((await main.call("todo_list")).details.count).toBe(1);
+  });
+
+  test("todo_list survives an absurd timestamp in the file", async () => {
+    const { call, todoFile } = fixture();
+    const created = (await call("todo_add", { text: "hand edited" })).details.task as TodoTask;
+    writeFileSync(
+      todoFile,
+      JSON.stringify([{ ...created, createdAt: 1e20, updatedAt: 1e20 }]),
+      "utf8",
+    );
+
+    const listed = await call("todo_list");
+    expect(listed.details.count).toBe(1);
+    expect(listed.content[0]!.text).toContain(String(1e20));
+    // The task stays reachable, so the agent can still delete it.
+    expect((await call("todo_delete", { id: created.id })).details.task.id).toBe(created.id);
+  });
+
+  test("load rebinds the controller to a session started later", async () => {
+    const { controller, directory } = fixture();
+    await controller.add("early task");
+
+    const later = join(directory, "later.jsonl");
+    controller.load(later);
+    expect(controller.sessionFile).toBe(later);
+    expect(controller.list()).toHaveLength(0);
+  });
+
+  test("the extension name carries the audience", () => {
+    expect(new TodoToolsController("main").extension().name).toBe("pum-todo-tools-main");
+    expect(new TodoToolsController("subagent").extension().name).toBe("pum-todo-tools-subagent");
+  });
+});

--- a/src/todo-tools.ts
+++ b/src/todo-tools.ts
@@ -1,0 +1,292 @@
+import type { ExtensionAPI, InlineExtension } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import {
+  addTodoTask,
+  deleteTodoTask,
+  loadTodoTasks,
+  MAX_TODO_TEXT,
+  MAX_TODOS,
+  sortTodoTasks,
+  TODO_STATUSES,
+  type TodoStatus,
+  type TodoTask,
+  updateTodoTask,
+  updateTodoTasks,
+} from "./todo";
+
+/**
+ * The five model tools over one agent's todo list.
+ *
+ * The controller is bound to the session it serves, so ownership never comes
+ * from tool input: the main agent reaches the main list and a child reaches
+ * its own, whatever the model asks for. No parameter names an agent, a
+ * session, or a file, which leaves nothing for a model to point elsewhere.
+ */
+
+export const TODO_TOOL_NAMES = [
+  "todo_list",
+  "todo_add",
+  "todo_update",
+  "todo_complete",
+  "todo_delete",
+] as const;
+
+export type TodoToolName = (typeof TODO_TOOL_NAMES)[number];
+
+export type TodoAudience = "main" | "subagent";
+
+const StatusSchema = Type.Union(TODO_STATUSES.map((status) => Type.Literal(status)), {
+  description: `Task status, one of: ${TODO_STATUSES.join(", ")}`,
+});
+
+const TextSchema = Type.String({
+  minLength: 1,
+  maxLength: MAX_TODO_TEXT,
+  description: `Task text, at most ${MAX_TODO_TEXT} characters`,
+});
+
+const IdSchema = Type.String({
+  minLength: 1,
+  description: "Stable task id, exactly as todo_list reports it",
+});
+
+/** Widest instant a Date holds. Beyond it toISOString throws a RangeError. */
+const MAX_EPOCH_MS = 8.64e15;
+
+/**
+ * A hand-edited file can carry a finite but absurd timestamp, which the state
+ * layer keeps. Printing it raw beats throwing: an agent that cannot list its
+ * tasks cannot find the id that would delete the bad one.
+ */
+function isoTime(epochMs: number): string {
+  if (!Number.isFinite(epochMs) || Math.abs(epochMs) > MAX_EPOCH_MS) return String(epochMs);
+  return new Date(epochMs).toISOString();
+}
+
+function taskLine(task: TodoTask): string {
+  return `${task.id} [${task.status}] ${task.text}`
+    + ` (created ${isoTime(task.createdAt)}, updated ${isoTime(task.updatedAt)})`;
+}
+
+function listText(tasks: readonly TodoTask[], status?: TodoStatus): string {
+  if (tasks.length === 0) return status ? `No ${status} tasks.` : "No tasks.";
+  const label = `${tasks.length} ${status ? `${status} ` : ""}task${tasks.length === 1 ? "" : "s"}`;
+  return [`${label}:`, ...tasks.map(taskLine)].join("\n");
+}
+
+/** Structured mirror of the text, so a UI never reparses the rendered lines. */
+function taskDetails(task: TodoTask) {
+  return {
+    id: task.id,
+    text: task.text,
+    status: task.status,
+    createdAt: task.createdAt,
+    updatedAt: task.updatedAt,
+  };
+}
+
+/**
+ * The state layer says which id it did not find; only the tool layer knows
+ * which call recovers it. Stale ids are the one error a model can fix alone.
+ */
+function withIdHint(error: unknown): never {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message.startsWith("unknown task id")) {
+    throw new Error(`${message}. Call todo_list for the ids that still exist.`);
+  }
+  throw error;
+}
+
+export class TodoToolsController {
+  readonly audience: TodoAudience;
+  private file: string | undefined;
+
+  constructor(audience: TodoAudience = "main", sessionFile?: string) {
+    this.audience = audience;
+    this.file = sessionFile;
+  }
+
+  /** The session file currently bound, if any. */
+  get sessionFile(): string | undefined {
+    return this.file;
+  }
+
+  /**
+   * Bind the session file. A session names its file only once it starts, so
+   * the controller is built first and pointed at the list afterwards.
+   */
+  load(sessionFile?: string): void {
+    if (sessionFile !== undefined) this.file = sessionFile;
+  }
+
+  /** This agent's tasks in canonical order, optionally one status only. */
+  list(status?: TodoStatus): TodoTask[] {
+    const tasks = sortTodoTasks(loadTodoTasks(this.file));
+    return status ? tasks.filter((task) => task.status === status) : tasks;
+  }
+
+  async add(text: string, status?: TodoStatus): Promise<TodoTask> {
+    let created: TodoTask | undefined;
+    await updateTodoTasks(this.file, (tasks) => {
+      const next = addTodoTask(tasks, text, status);
+      created = next[next.length - 1];
+      return next;
+    });
+    // The mutation ran and returned, so the appended task exists.
+    return created as TodoTask;
+  }
+
+  async update(id: string, changes: { text?: string; status?: TodoStatus }): Promise<TodoTask> {
+    if (changes.text === undefined && changes.status === undefined) {
+      throw new Error("nothing to change: pass text, status, or both");
+    }
+    const tasks = await updateTodoTasks(
+      this.file,
+      (current) => updateTodoTask(current, id, changes),
+    ).catch(withIdHint);
+    return tasks.find((task) => task.id === id) as TodoTask;
+  }
+
+  /** Completing a completed task is a no-op, not an error. */
+  async complete(id: string): Promise<TodoTask> {
+    const tasks = await updateTodoTasks(
+      this.file,
+      (current) => updateTodoTask(current, id, { status: "completed" }),
+    ).catch(withIdHint);
+    return tasks.find((task) => task.id === id) as TodoTask;
+  }
+
+  async delete(id: string): Promise<TodoTask> {
+    let deleted: TodoTask | undefined;
+    await updateTodoTasks(this.file, (tasks) => {
+      deleted = tasks.find((task) => task.id === id);
+      return deleteTodoTask(tasks, id);
+    }).catch(withIdHint);
+    return deleted as TodoTask;
+  }
+
+  registerTool(pi: Pick<ExtensionAPI, "registerTool">): void {
+    const controller = this;
+
+    pi.registerTool({
+      name: "todo_list",
+      label: "Todo List",
+      description: "List this agent's tasks in priority order, optionally one status only.",
+      promptSnippet: "List the current tasks with their stable ids",
+      promptGuidelines: [
+        "Call todo_list before todo_update, todo_complete or todo_delete to get current ids.",
+        "The list belongs to the calling agent. There is no way to read another agent's tasks.",
+      ],
+      parameters: Type.Object({
+        status: Type.Optional(StatusSchema),
+      }, { additionalProperties: false }),
+      executionMode: "sequential",
+      execute: async (_id, params) => {
+        const tasks = controller.list(params.status);
+        return {
+          content: [{ type: "text" as const, text: listText(tasks, params.status) }],
+          details: {
+            action: "list",
+            count: tasks.length,
+            status: params.status,
+            tasks: tasks.map(taskDetails),
+          },
+        };
+      },
+    });
+
+    pi.registerTool({
+      name: "todo_add",
+      label: "Todo Add",
+      description:
+        `Add one task to this agent's list. Status defaults to pending. The list holds at most ${MAX_TODOS} tasks.`,
+      promptSnippet: "Add one task to the current agent's list",
+      promptGuidelines: [
+        "Write one concrete task per call. Do not pack several steps into one text.",
+        "Do not put agent, session or file names in the input. PUM binds the calling agent's list.",
+      ],
+      parameters: Type.Object({
+        text: TextSchema,
+        status: Type.Optional(StatusSchema),
+      }, { additionalProperties: false }),
+      executionMode: "sequential",
+      execute: async (_id, params) => {
+        const task = await controller.add(params.text, params.status);
+        return {
+          content: [{ type: "text" as const, text: `Added task ${task.id}.\n${taskLine(task)}` }],
+          details: { action: "add", count: 1, task: taskDetails(task) },
+        };
+      },
+    });
+
+    pi.registerTool({
+      name: "todo_update",
+      label: "Todo Update",
+      description: "Change the text, the status, or both of one task. At least one of them is required.",
+      promptSnippet: "Change the text or status of one task",
+      promptGuidelines: [
+        "Set status to active when work starts and to blocked when it stops, so the list stays honest.",
+        "Use todo_complete rather than todo_update to finish a task.",
+      ],
+      parameters: Type.Object({
+        id: IdSchema,
+        text: Type.Optional(TextSchema),
+        status: Type.Optional(StatusSchema),
+      }, { additionalProperties: false }),
+      executionMode: "sequential",
+      execute: async (_id, params) => {
+        const task = await controller.update(params.id, { text: params.text, status: params.status });
+        return {
+          content: [{ type: "text" as const, text: `Updated task ${task.id}.\n${taskLine(task)}` }],
+          details: { action: "update", count: 1, task: taskDetails(task) },
+        };
+      },
+    });
+
+    pi.registerTool({
+      name: "todo_complete",
+      label: "Todo Complete",
+      description: "Mark one task completed. Completing an already completed task changes nothing and still succeeds.",
+      promptSnippet: "Mark one task completed",
+      promptGuidelines: [
+        "Complete a task as soon as its work is done, not in a batch at the end.",
+      ],
+      parameters: Type.Object({ id: IdSchema }, { additionalProperties: false }),
+      executionMode: "sequential",
+      execute: async (_id, params) => {
+        const task = await controller.complete(params.id);
+        return {
+          content: [{ type: "text" as const, text: `Completed task ${task.id}.\n${taskLine(task)}` }],
+          details: { action: "complete", count: 1, task: taskDetails(task) },
+        };
+      },
+    });
+
+    pi.registerTool({
+      name: "todo_delete",
+      label: "Todo Delete",
+      description: "Remove one task from this agent's list, whatever its status.",
+      promptSnippet: "Remove one task from the current agent's list",
+      promptGuidelines: [
+        "Delete a task that turned out to be wrong or duplicated. Completed work is worth keeping.",
+      ],
+      parameters: Type.Object({ id: IdSchema }, { additionalProperties: false }),
+      executionMode: "sequential",
+      execute: async (_id, params) => {
+        const task = await controller.delete(params.id);
+        return {
+          content: [{ type: "text" as const, text: `Deleted task ${task.id}.\n${taskLine(task)}` }],
+          details: { action: "delete", count: 1, task: taskDetails(task) },
+        };
+      },
+    });
+  }
+
+  /** The inline extension that registers the todo tools for one session. */
+  extension(): InlineExtension {
+    return {
+      name: `pum-todo-tools-${this.audience}`,
+      factory: (pi) => this.registerTool(pi),
+    };
+  }
+}

--- a/src/todo-tools.ts
+++ b/src/todo-tools.ts
@@ -35,6 +35,9 @@ export type TodoToolName = (typeof TODO_TOOL_NAMES)[number];
 
 export type TodoAudience = "main" | "subagent";
 
+/** A mutation and whether it moved anything. A repeat is success, not change. */
+export type TodoChange = { task: TodoTask; changed: boolean };
+
 const StatusSchema = Type.Union(TODO_STATUSES.map((status) => Type.Literal(status)), {
   description: `Task status, one of: ${TODO_STATUSES.join(", ")}`,
 });
@@ -86,13 +89,20 @@ function taskDetails(task: TodoTask) {
 }
 
 /**
- * The state layer says which id it did not find; only the tool layer knows
- * which call recovers it. Stale ids are the one error a model can fix alone.
+ * The state layer says what went wrong; only the tool layer knows which call
+ * recovers it. A stale id and a full list are the two errors a model can fix
+ * on its own, so both leave with the next move attached.
  */
-function withIdHint(error: unknown): never {
+function withHint(error: unknown): never {
   const message = error instanceof Error ? error.message : String(error);
   if (message.startsWith("unknown task id")) {
-    throw new Error(`${message}. Call todo_list for the ids that still exist.`);
+    throw new Error(`${message}. Call todo_list for the ids that still exist.`, { cause: error });
+  }
+  if (message.startsWith("the list holds at most")) {
+    throw new Error(
+      `${message}. Complete or delete one before adding another.`,
+      { cause: error },
+    );
   }
   throw error;
 }
@@ -101,9 +111,9 @@ export class TodoToolsController {
   readonly audience: TodoAudience;
   private file: string | undefined;
 
-  constructor(audience: TodoAudience = "main", sessionFile?: string) {
+  constructor(audience: TodoAudience = "main", sessionFile?: string | null) {
+    this.file = sessionFile || undefined;
     this.audience = audience;
-    this.file = sessionFile;
   }
 
   /** The session file currently bound, if any. */
@@ -113,56 +123,86 @@ export class TodoToolsController {
 
   /**
    * Bind the session file. A session names its file only once it starts, so
-   * the controller is built first and pointed at the list afterwards.
+   * the controller is built first and pointed at the list afterwards. No name
+   * unbinds: a controller reused for a fresh run must not keep writing to the
+   * list of the session it served before.
    */
-  load(sessionFile?: string): void {
-    if (sessionFile !== undefined) this.file = sessionFile;
+  load(sessionFile?: string | null): void {
+    this.file = sessionFile || undefined;
+  }
+
+  /**
+   * The file this agent's list lives in.
+   *
+   * A run with no session file keeps its list in memory, and every unbound
+   * writer in the process shares that one list. The main agent is the only
+   * one of its kind, so it can own it; a child with no file of its own would
+   * be reading the main agent's tasks, and gets no list at all instead.
+   */
+  private bound(): string | undefined {
+    if (this.file === undefined && this.audience !== "main") {
+      throw new Error("this agent has no todo list: its session started without a file to keep one in");
+    }
+    return this.file;
   }
 
   /** This agent's tasks in canonical order, optionally one status only. */
   list(status?: TodoStatus): TodoTask[] {
-    const tasks = sortTodoTasks(loadTodoTasks(this.file));
+    // A plain read is enough: a write lands whole through a rename, and the
+    // tools run one at a time, so there is no half-written list to catch.
+    const tasks = sortTodoTasks(loadTodoTasks(this.bound()));
     return status ? tasks.filter((task) => task.status === status) : tasks;
   }
 
   async add(text: string, status?: TodoStatus): Promise<TodoTask> {
     let created: TodoTask | undefined;
-    await updateTodoTasks(this.file, (tasks) => {
+    await updateTodoTasks(this.bound(), (tasks) => {
+      // By id, not by position: where the new task lands is not this layer's
+      // business, and reporting the wrong one would be silent.
+      const before = new Set(tasks.map((task) => task.id));
       const next = addTodoTask(tasks, text, status);
-      created = next[next.length - 1];
+      created = next.find((task) => !before.has(task.id));
       return next;
-    });
-    // The mutation ran and returned, so the appended task exists.
+    }).catch(withHint);
     return created as TodoTask;
   }
 
-  async update(id: string, changes: { text?: string; status?: TodoStatus }): Promise<TodoTask> {
+  async update(id: string, changes: { text?: string; status?: TodoStatus }): Promise<TodoChange> {
     if (changes.text === undefined && changes.status === undefined) {
       throw new Error("nothing to change: pass text, status, or both");
     }
-    const tasks = await updateTodoTasks(
-      this.file,
-      (current) => updateTodoTask(current, id, changes),
-    ).catch(withIdHint);
-    return tasks.find((task) => task.id === id) as TodoTask;
+    return this.apply(id, changes);
   }
 
   /** Completing a completed task is a no-op, not an error. */
-  async complete(id: string): Promise<TodoTask> {
-    const tasks = await updateTodoTasks(
-      this.file,
-      (current) => updateTodoTask(current, id, { status: "completed" }),
-    ).catch(withIdHint);
-    return tasks.find((task) => task.id === id) as TodoTask;
+  async complete(id: string): Promise<TodoChange> {
+    return this.apply(id, { status: "completed" });
   }
 
   async delete(id: string): Promise<TodoTask> {
     let deleted: TodoTask | undefined;
-    await updateTodoTasks(this.file, (tasks) => {
+    await updateTodoTasks(this.bound(), (tasks) => {
       deleted = tasks.find((task) => task.id === id);
       return deleteTodoTask(tasks, id);
-    }).catch(withIdHint);
+    }).catch(withHint);
     return deleted as TodoTask;
+  }
+
+  private async apply(
+    id: string,
+    changes: { text?: string; status?: TodoStatus },
+  ): Promise<TodoChange> {
+    let before: TodoTask | undefined;
+    const tasks = await updateTodoTasks(this.bound(), (current) => {
+      before = current.find((task) => task.id === id);
+      return updateTodoTask(current, id, changes);
+    }).catch(withHint);
+    // The mutation returned, so the id is there.
+    const task = tasks.find((candidate) => candidate.id === id) as TodoTask;
+    // Comparing the fields, not updatedAt: two changes in one millisecond
+    // share a timestamp and the second would read as a no-op.
+    const changed = !before || before.text !== task.text || before.status !== task.status;
+    return { task, changed };
   }
 
   registerTool(pi: Pick<ExtensionAPI, "registerTool">): void {
@@ -235,10 +275,16 @@ export class TodoToolsController {
       }, { additionalProperties: false }),
       executionMode: "sequential",
       execute: async (_id, params) => {
-        const task = await controller.update(params.id, { text: params.text, status: params.status });
+        const { task, changed } = await controller.update(params.id, {
+          text: params.text,
+          status: params.status,
+        });
+        const headline = changed
+          ? `Updated task ${task.id}.`
+          : `Task ${task.id} already read that way; nothing changed.`;
         return {
-          content: [{ type: "text" as const, text: `Updated task ${task.id}.\n${taskLine(task)}` }],
-          details: { action: "update", count: 1, task: taskDetails(task) },
+          content: [{ type: "text" as const, text: `${headline}\n${taskLine(task)}` }],
+          details: { action: "update", count: 1, changed, task: taskDetails(task) },
         };
       },
     });
@@ -254,10 +300,13 @@ export class TodoToolsController {
       parameters: Type.Object({ id: IdSchema }, { additionalProperties: false }),
       executionMode: "sequential",
       execute: async (_id, params) => {
-        const task = await controller.complete(params.id);
+        const { task, changed } = await controller.complete(params.id);
+        const headline = changed
+          ? `Completed task ${task.id}.`
+          : `Task ${task.id} was already completed.`;
         return {
-          content: [{ type: "text" as const, text: `Completed task ${task.id}.\n${taskLine(task)}` }],
-          details: { action: "complete", count: 1, task: taskDetails(task) },
+          content: [{ type: "text" as const, text: `${headline}\n${taskLine(task)}` }],
+          details: { action: "complete", count: 1, changed, task: taskDetails(task) },
         };
       },
     });

--- a/src/todo.test.ts
+++ b/src/todo.test.ts
@@ -1,0 +1,364 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import {
+  MAX_TODOS,
+  MAX_TODO_TEXT,
+  TODO_STATUSES,
+  addTodoTask,
+  createTodoTask,
+  deleteTodoTask,
+  isTodoStatus,
+  loadTodoTasks,
+  normalizeTodoText,
+  saveTodoTasks,
+  sortTodoTasks,
+  todoFileFor,
+  updateTodoTask,
+  updateTodoTasks,
+  type TodoTask,
+} from "./todo";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function tempSessionFile(): string {
+  const directory = mkdtempSync(join(tmpdir(), "pum-todo-"));
+  temporaryDirectories.push(directory);
+  return join(directory, "session-id.jsonl");
+}
+
+function task(partial: Partial<TodoTask> = {}): TodoTask {
+  return {
+    id: "task-1",
+    text: "write the parser",
+    status: "pending",
+    createdAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_000_000,
+    ...partial,
+  };
+}
+
+describe("task creation", () => {
+  test("trims the text and defaults to pending", () => {
+    expect(createTodoTask("  write the parser  ", undefined, 42, "task-1")).toEqual({
+      id: "task-1",
+      text: "write the parser",
+      status: "pending",
+      createdAt: 42,
+      updatedAt: 42,
+    });
+  });
+
+  test("keeps a supplied valid status", () => {
+    expect(createTodoTask("ship it", "active", 42, "task-1").status).toBe("active");
+  });
+
+  test("rejects empty, blank and overlong text", () => {
+    expect(() => createTodoTask("")).toThrow("a task needs text");
+    expect(() => createTodoTask("   ")).toThrow("a task needs text");
+    expect(() => createTodoTask("\n\t")).toThrow("a task needs text");
+    expect(() => createTodoTask("x".repeat(MAX_TODO_TEXT + 1))).toThrow(String(MAX_TODO_TEXT));
+  });
+
+  test("rejects NUL and escape, and folds a newline into one space", () => {
+    expect(() => createTodoTask("bad\0text")).toThrow("control characters");
+    expect(() => createTodoTask("clear\u001b[2Jthe screen")).toThrow("control characters");
+    expect(normalizeTodoText("write  the\n\tparser")).toBe("write the parser");
+  });
+
+  test("accepts text at exactly the limit", () => {
+    expect(normalizeTodoText("x".repeat(MAX_TODO_TEXT))).toHaveLength(MAX_TODO_TEXT);
+  });
+
+  test("rejects an unknown status", () => {
+    expect(() => createTodoTask("ship it", "done")).toThrow("unknown task status");
+    expect(isTodoStatus("done")).toBe(false);
+    expect(TODO_STATUSES.every(isTodoStatus)).toBe(true);
+  });
+});
+
+describe("canonical order", () => {
+  test("orders by status, then oldest first, then id", () => {
+    const tasks: TodoTask[] = [
+      task({ id: "e", status: "cancelled", createdAt: 1 }),
+      task({ id: "d", status: "completed", createdAt: 1 }),
+      task({ id: "c", status: "blocked", createdAt: 1 }),
+      task({ id: "b", status: "pending", createdAt: 1 }),
+      task({ id: "a", status: "active", createdAt: 1 }),
+    ];
+    expect(sortTodoTasks(tasks).map((entry) => entry.id)).toEqual(["a", "b", "c", "d", "e"]);
+  });
+
+  test("breaks a status tie by createdAt then by id", () => {
+    const tasks: TodoTask[] = [
+      task({ id: "z", createdAt: 5 }),
+      task({ id: "a", createdAt: 9 }),
+      task({ id: "b", createdAt: 5 }),
+    ];
+    expect(sortTodoTasks(tasks).map((entry) => entry.id)).toEqual(["b", "z", "a"]);
+  });
+
+  test("leaves the input untouched", () => {
+    const tasks: TodoTask[] = [task({ id: "b", status: "completed" }), task({ id: "a" })];
+    sortTodoTasks(tasks);
+    expect(tasks.map((entry) => entry.id)).toEqual(["b", "a"]);
+  });
+});
+
+describe("mutation", () => {
+  test("appends and rejects a duplicate id", () => {
+    const one = addTodoTask([], "first", undefined, 1, "task-1");
+    expect(one).toHaveLength(1);
+    expect(() => addTodoTask(one, "again", undefined, 2, "task-1")).toThrow("duplicate task id");
+  });
+
+  test("updates text and status and bumps updatedAt", () => {
+    const tasks = [task()];
+    const next = updateTodoTask(tasks, "task-1", { status: "active" }, 99);
+    expect(next[0]).toMatchObject({ status: "active", updatedAt: 99 });
+    expect(tasks[0]?.status).toBe("pending");
+  });
+
+  test("leaves updatedAt alone when nothing changes", () => {
+    const next = updateTodoTask([task()], "task-1", { text: "write the parser" }, 99);
+    expect(next[0]?.updatedAt).toBe(1_700_000_000_000);
+  });
+
+  test("rejects an unknown id, unknown status and bad text", () => {
+    expect(() => updateTodoTask([task()], "nope", { status: "active" })).toThrow("unknown task id");
+    expect(() => updateTodoTask([task()], "task-1", { status: "done" })).toThrow("unknown task status");
+    expect(() => updateTodoTask([task()], "task-1", { text: "" })).toThrow("a task needs text");
+    expect(() => deleteTodoTask([task()], "nope")).toThrow("unknown task id");
+  });
+
+  test("deletes only the named task", () => {
+    const tasks = [task({ id: "a" }), task({ id: "b", status: "completed" })];
+    expect(deleteTodoTask(tasks, "a").map((entry) => entry.id)).toEqual(["b"]);
+  });
+});
+
+describe("the task cap", () => {
+  function fill(count: number): TodoTask[] {
+    return Array.from({ length: count }, (_unused, index) =>
+      task({ id: `task-${index}`, createdAt: index }));
+  }
+
+  test("accepts the hundredth task and rejects the hundred and first", () => {
+    const full = addTodoTask(fill(MAX_TODOS - 1), "last", undefined, 1, "task-last");
+    expect(full).toHaveLength(MAX_TODOS);
+    expect(() => addTodoTask(full, "one too many", undefined, 2, "task-extra"))
+      .toThrow(`at most ${MAX_TODOS}`);
+  });
+
+  test("counts completed and cancelled tasks too", () => {
+    const finished = fill(MAX_TODOS).map((entry, index) => ({
+      ...entry,
+      status: index % 2 === 0 ? ("completed" as const) : ("cancelled" as const),
+    }));
+    expect(() => addTodoTask(finished, "one more", undefined, 1, "task-extra"))
+      .toThrow(`at most ${MAX_TODOS}`);
+  });
+});
+
+describe("the companion file path", () => {
+  test("sits beside the session with the host separator", () => {
+    const sessionFile = join("some", "dir", "session-id.jsonl");
+    const file = todoFileFor(sessionFile);
+    expect(basename(file)).toBe("session-id.todo.json");
+    expect(dirname(file)).toBe(join("some", "dir"));
+  });
+
+  test("strips a .json session suffix as well", () => {
+    expect(basename(todoFileFor(join("d", "abc.json")))).toBe("abc.todo.json");
+  });
+});
+
+describe("persistence", () => {
+  test("round-trips a saved list", () => {
+    const sessionFile = tempSessionFile();
+    const tasks = [task({ id: "a" }), task({ id: "b", status: "completed" })];
+    saveTodoTasks(sessionFile, tasks);
+    expect(loadTodoTasks(sessionFile)).toEqual(tasks);
+  });
+
+  test("leaves no temp file behind and renames into place", () => {
+    const sessionFile = tempSessionFile();
+    saveTodoTasks(sessionFile, [task()]);
+    const written = readdirSync(dirname(sessionFile));
+    expect(written).toEqual(["session-id.todo.json"]);
+  });
+
+  test("writes nothing for an empty list with no file", () => {
+    const sessionFile = tempSessionFile();
+    saveTodoTasks(sessionFile, []);
+    expect(existsSync(todoFileFor(sessionFile))).toBe(false);
+    expect(loadTodoTasks(sessionFile)).toEqual([]);
+  });
+
+  test("clears an existing file down to an empty list", () => {
+    const sessionFile = tempSessionFile();
+    saveTodoTasks(sessionFile, [task()]);
+    saveTodoTasks(sessionFile, []);
+    expect(loadTodoTasks(sessionFile)).toEqual([]);
+    expect(existsSync(todoFileFor(sessionFile))).toBe(true);
+  });
+
+  test("holds a sessionless list in memory instead of a file", () => {
+    expect(loadTodoTasks(undefined)).toEqual([]);
+    saveTodoTasks(undefined, [task()]);
+    expect(loadTodoTasks(undefined)).toEqual([task()]);
+    saveTodoTasks(undefined, []);
+    expect(loadTodoTasks(undefined)).toEqual([]);
+  });
+
+  test("returns an empty list for corrupt, non-array and missing files", () => {
+    const sessionFile = tempSessionFile();
+    expect(loadTodoTasks(sessionFile)).toEqual([]);
+    writeFileSync(todoFileFor(sessionFile), "{ not json", "utf8");
+    expect(loadTodoTasks(sessionFile)).toEqual([]);
+    writeFileSync(todoFileFor(sessionFile), JSON.stringify({ tasks: [] }), "utf8");
+    expect(loadTodoTasks(sessionFile)).toEqual([]);
+  });
+
+  test("drops invalid entries instead of failing the whole load", () => {
+    const sessionFile = tempSessionFile();
+    writeFileSync(todoFileFor(sessionFile), JSON.stringify([
+      task({ id: "good" }),
+      null,
+      "task",
+      { ...task({ id: "no-status" }), status: "done" },
+      { ...task({ id: "blank" }), text: "   " },
+      { ...task({ id: "nul" }), text: "bad\0text" },
+      { ...task({ id: "long" }), text: "x".repeat(MAX_TODO_TEXT + 1) },
+      { ...task({ id: "" }) },
+      { ...task({ id: "no-time" }), createdAt: "yesterday" },
+      task({ id: "also-good", status: "active" }),
+    ]), "utf8");
+    expect(loadTodoTasks(sessionFile).map((entry) => entry.id)).toEqual(["good", "also-good"]);
+  });
+
+  test("keeps the first of two entries sharing an id", () => {
+    const sessionFile = tempSessionFile();
+    writeFileSync(todoFileFor(sessionFile), JSON.stringify([
+      task({ id: "dupe", text: "first" }),
+      task({ id: "dupe", text: "second" }),
+    ]), "utf8");
+    const loaded = loadTodoTasks(sessionFile);
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0]?.text).toBe("first");
+  });
+
+  test("caps an oversized file by dropping the lowest-priority tasks", () => {
+    const sessionFile = tempSessionFile();
+    writeFileSync(todoFileFor(sessionFile), JSON.stringify([
+      ...Array.from({ length: MAX_TODOS + 19 }, (_unused, index) =>
+        task({ id: `done-${index}`, status: "completed", createdAt: index })),
+      task({ id: "still-running", status: "active", createdAt: 5_000 }),
+    ]), "utf8");
+    const loaded = loadTodoTasks(sessionFile);
+    expect(loaded).toHaveLength(MAX_TODOS);
+    // The active task sits last in the file and must survive the cap.
+    expect(loaded.map((entry) => entry.id)).toContain("still-running");
+  });
+
+  test("keeps file order when the file fits", () => {
+    const sessionFile = tempSessionFile();
+    const tasks = [task({ id: "b", status: "completed" }), task({ id: "a", status: "active" })];
+    saveTodoTasks(sessionFile, tasks);
+    expect(loadTodoTasks(sessionFile).map((entry) => entry.id)).toEqual(["b", "a"]);
+  });
+});
+
+describe("serialized updates", () => {
+  test("keeps every task when writers run in parallel", async () => {
+    const sessionFile = tempSessionFile();
+    const results = await Promise.all(
+      Array.from({ length: 10 }, (_unused, index) =>
+        updateTodoTasks(sessionFile, (tasks) =>
+          addTodoTask(tasks, `task ${index}`, undefined, index, `task-${index}`))),
+    );
+    expect(results.at(-1)).toHaveLength(10);
+    expect(loadTodoTasks(sessionFile)).toHaveLength(10);
+  });
+
+  test("holds the cap against parallel writers", async () => {
+    const sessionFile = tempSessionFile();
+    saveTodoTasks(sessionFile, Array.from({ length: MAX_TODOS - 1 }, (_unused, index) =>
+      task({ id: `seed-${index}`, createdAt: index })));
+    const settled = await Promise.allSettled(
+      Array.from({ length: 3 }, (_unused, index) =>
+        updateTodoTasks(sessionFile, (tasks) =>
+          addTodoTask(tasks, `late ${index}`, undefined, index, `late-${index}`))),
+    );
+    expect(settled.filter((entry) => entry.status === "fulfilled")).toHaveLength(1);
+    expect(loadTodoTasks(sessionFile)).toHaveLength(MAX_TODOS);
+  });
+
+  test("a rejected mutation leaves the file untouched", async () => {
+    const sessionFile = tempSessionFile();
+    await updateTodoTasks(sessionFile, (tasks) =>
+      addTodoTask(tasks, "keep me", undefined, 1, "task-1"));
+    const before = readFileSync(todoFileFor(sessionFile), "utf8");
+    await expect(updateTodoTasks(sessionFile, (tasks) =>
+      updateTodoTask(tasks, "gone", { status: "completed" }))).rejects.toThrow("unknown task id");
+    expect(readFileSync(todoFileFor(sessionFile), "utf8")).toBe(before);
+  });
+
+  test("a rejection does not poison later writers", async () => {
+    const sessionFile = tempSessionFile();
+    const failed = updateTodoTasks(sessionFile, () => {
+      throw new Error("boom");
+    });
+    const added = updateTodoTasks(sessionFile, (tasks) =>
+      addTodoTask(tasks, "after the failure", undefined, 1, "task-1"));
+    await expect(failed).rejects.toThrow("boom");
+    expect(await added).toHaveLength(1);
+  });
+
+  test("refuses to store a duplicate id a mutation invents", async () => {
+    const sessionFile = tempSessionFile();
+    await expect(updateTodoTasks(sessionFile, () => [task({ id: "same" }), task({ id: "same" })]))
+      .rejects.toThrow("duplicate task id");
+    expect(existsSync(todoFileFor(sessionFile))).toBe(false);
+  });
+
+  test("keeps a sessionless list in memory", async () => {
+    try {
+      expect(await updateTodoTasks(undefined, (tasks) =>
+        addTodoTask(tasks, "nowhere", undefined, 1, "task-1"))).toHaveLength(1);
+      expect(loadTodoTasks(undefined).map((entry) => entry.text)).toEqual(["nowhere"]);
+      expect(await updateTodoTasks(undefined, (tasks) =>
+        deleteTodoTask(tasks, "task-1"))).toEqual([]);
+      await expect(updateTodoTasks(undefined, (tasks) =>
+        deleteTodoTask(tasks, "task-1"))).rejects.toThrow("unknown task id");
+    } finally {
+      saveTodoTasks(undefined, []);
+    }
+  });
+
+  test("reports a failed write instead of claiming success", async () => {
+    const sessionFile = tempSessionFile();
+    // A directory where the companion file belongs fails the rename on every
+    // platform, which is the cheapest stand-in for a full or read-only disk.
+    mkdirSync(todoFileFor(sessionFile));
+    await expect(updateTodoTasks(sessionFile, (tasks) =>
+      addTodoTask(tasks, "unwritable", undefined, 1, "task-1"))).rejects.toThrow();
+    // The temp file goes with it; a failed write leaves nothing behind.
+    expect(readdirSync(dirname(sessionFile))).toEqual(["session-id.todo.json"]);
+  });
+});

--- a/src/todo.ts
+++ b/src/todo.ts
@@ -1,0 +1,292 @@
+import { basename, dirname, join } from "node:path";
+import { existsSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+
+/**
+ * Per-agent todo lists.
+ *
+ * A pure state layer: validation, canonical ordering, and a companion file
+ * beside the session JSONL. Tools and the popup build on this and own no
+ * state of their own, so every writer shares one cap and one order.
+ */
+
+export type TodoStatus = "pending" | "active" | "blocked" | "completed" | "cancelled";
+
+/**
+ * Canonical status order. Sorting and the status guard both read this array,
+ * so a new status can only ever be added in one place.
+ */
+export const TODO_STATUSES: readonly TodoStatus[] = [
+  "active",
+  "pending",
+  "blocked",
+  "completed",
+  "cancelled",
+];
+
+/** Longest task text PUM stores. Longer input is refused, never truncated. */
+export const MAX_TODO_TEXT = 500;
+
+/** The list never holds more than this many tasks, whatever their status. */
+export const MAX_TODOS = 100;
+
+export type TodoTask = {
+  /** Stable opaque identifier. */
+  id: string;
+  /** Non-empty task text, at most MAX_TODO_TEXT characters. */
+  text: string;
+  status: TodoStatus;
+  /** Epoch milliseconds. */
+  createdAt: number;
+  /** Epoch milliseconds of the last accepted change. */
+  updatedAt: number;
+};
+
+export function isTodoStatus(value: unknown): value is TodoStatus {
+  return TODO_STATUSES.includes(value as TodoStatus);
+}
+
+/** Companion file next to the session JSONL: <session>.todo.json */
+export function todoFileFor(sessionFile: string): string {
+  const base = basename(sessionFile).replace(/\.jsonl?$/, "");
+  return join(dirname(sessionFile), `${base}.todo.json`);
+}
+
+/**
+ * NUL truncates the text in C string APIs, and ESC lets task text repaint the
+ * terminal the popup draws it into. Tab, newline and return collapse to a
+ * space before this runs, so only the harmful controls reach it.
+ */
+const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f-\u009f]/;
+
+/** Flatten and check task text. Throws with the reason the caller should show. */
+export function normalizeTodoText(value: unknown): string {
+  if (typeof value !== "string") throw new Error("a task needs text");
+  // A task is one line in the popup, so runs of whitespace become one space.
+  const text = value.replace(/\s+/g, " ").trim();
+  if (!text) throw new Error("a task needs text");
+  if (CONTROL_CHARACTERS.test(text)) {
+    throw new Error("task text cannot hold control characters");
+  }
+  if (text.length > MAX_TODO_TEXT) {
+    throw new Error(`a task is at most ${MAX_TODO_TEXT} characters`);
+  }
+  return text;
+}
+
+function normalizeStatus(value: unknown): TodoStatus {
+  if (value === undefined) return "pending";
+  if (!isTodoStatus(value)) throw new Error(`unknown task status: ${String(value)}`);
+  return value;
+}
+
+export function createTodoTask(
+  text: string,
+  status?: unknown,
+  now = Date.now(),
+  id = randomUUID().slice(0, 12),
+): TodoTask {
+  return {
+    id,
+    text: normalizeTodoText(text),
+    status: normalizeStatus(status),
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+/**
+ * Canonical order: status, then oldest first, then id so two tasks written in
+ * the same millisecond never swap places between renders.
+ */
+export function sortTodoTasks(tasks: readonly TodoTask[]): TodoTask[] {
+  return [...tasks].sort((left, right) => {
+    const byStatus = TODO_STATUSES.indexOf(left.status) - TODO_STATUSES.indexOf(right.status);
+    if (byStatus !== 0) return byStatus;
+    if (left.createdAt !== right.createdAt) return left.createdAt - right.createdAt;
+    return left.id < right.id ? -1 : left.id > right.id ? 1 : 0;
+  });
+}
+
+/** Append a task. Throws when the text is bad or the list is full. */
+export function addTodoTask(
+  tasks: readonly TodoTask[],
+  text: string,
+  status?: unknown,
+  now = Date.now(),
+  id = randomUUID().slice(0, 12),
+): TodoTask[] {
+  const task = createTodoTask(text, status, now, id);
+  if (tasks.length >= MAX_TODOS) throw new Error(`the list holds at most ${MAX_TODOS} tasks`);
+  if (tasks.some((existing) => existing.id === task.id)) {
+    throw new Error(`duplicate task id: ${task.id}`);
+  }
+  return [...tasks, task];
+}
+
+/** Change text, status, or both. Throws on an unknown id or bad input. */
+export function updateTodoTask(
+  tasks: readonly TodoTask[],
+  id: string,
+  changes: { text?: string; status?: unknown },
+  now = Date.now(),
+): TodoTask[] {
+  const index = tasks.findIndex((task) => task.id === id);
+  if (index < 0) throw new Error(`unknown task id: ${id}`);
+  const current = tasks[index] as TodoTask;
+  const text = changes.text === undefined ? current.text : normalizeTodoText(changes.text);
+  const status = changes.status === undefined ? current.status : normalizeStatus(changes.status);
+  // A no-op must not bump updatedAt, or reordering by time would drift.
+  if (text === current.text && status === current.status) return [...tasks];
+  const next = [...tasks];
+  next[index] = { ...current, text, status, updatedAt: now };
+  return next;
+}
+
+/** Drop a task. Completed and cancelled ones only leave this way. */
+export function deleteTodoTask(tasks: readonly TodoTask[], id: string): TodoTask[] {
+  const index = tasks.findIndex((task) => task.id === id);
+  if (index < 0) throw new Error(`unknown task id: ${id}`);
+  return tasks.filter((_, at) => at !== index);
+}
+
+function isTodoTask(value: unknown): value is TodoTask {
+  if (!value || typeof value !== "object") return false;
+  const task = value as Record<string, unknown>;
+  return (
+    typeof task.id === "string" && task.id.length > 0 && !CONTROL_CHARACTERS.test(task.id) &&
+    typeof task.text === "string" &&
+    task.text.trim().length > 0 &&
+    task.text.length <= MAX_TODO_TEXT &&
+    !CONTROL_CHARACTERS.test(task.text) &&
+    isTodoStatus(task.status) &&
+    typeof task.createdAt === "number" && Number.isFinite(task.createdAt) &&
+    typeof task.updatedAt === "number" && Number.isFinite(task.updatedAt)
+  );
+}
+
+/**
+ * A run with no session file still needs a working list, so it keeps one in
+ * memory. It dies with the process; there is nothing to persist.
+ */
+let sessionlessTasks: readonly TodoTask[] = [];
+
+/**
+ * Load the persisted list for a session. Never throws: a missing, unreadable
+ * or corrupt file reads as an empty list, and single bad entries are dropped.
+ */
+export function loadTodoTasks(sessionFile: string | undefined): TodoTask[] {
+  if (!sessionFile) return [...sessionlessTasks];
+  try {
+    const file = todoFileFor(sessionFile);
+    if (!existsSync(file)) return [];
+    const parsed: unknown = JSON.parse(readFileSync(file, "utf8"));
+    if (!Array.isArray(parsed)) return [];
+    const seen = new Set<string>();
+    const tasks: TodoTask[] = [];
+    for (const entry of parsed) {
+      if (!isTodoTask(entry)) continue;
+      // A file edited by hand can repeat an id; the first one wins so every
+      // later lookup by id stays unambiguous.
+      if (seen.has(entry.id)) continue;
+      seen.add(entry.id);
+      tasks.push({
+        id: entry.id,
+        text: entry.text,
+        status: entry.status,
+        createdAt: entry.createdAt,
+        updatedAt: entry.updatedAt,
+      });
+    }
+    // File order is arbitrary, so an oversized file drops its lowest-priority
+    // tasks rather than whatever happens to sit past the hundredth line.
+    return tasks.length > MAX_TODOS ? sortTodoTasks(tasks).slice(0, MAX_TODOS) : tasks;
+  } catch {
+    return [];
+  }
+}
+
+/** Write the list atomically. Throws so a caller in a transaction can react. */
+function writeTodoTasks(sessionFile: string | undefined, tasks: readonly TodoTask[]): void {
+  if (!sessionFile) {
+    sessionlessTasks = [...tasks];
+    return;
+  }
+  const file = todoFileFor(sessionFile);
+  // An empty list with no companion file is nothing to record. Writing it
+  // would leave a two-byte "[]" beside every session ever opened.
+  if (tasks.length === 0 && !existsSync(file)) return;
+  // The temp name carries pid and time so two PUM processes on one session
+  // cannot clobber each other's half-written file before the rename.
+  const temporary = `${file}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    writeFileSync(temporary, JSON.stringify(tasks.slice(0, MAX_TODOS), null, 2), "utf8");
+    renameSync(temporary, file);
+  } catch (error) {
+    // The name is never reused, so a leftover temp file would sit there forever.
+    try {
+      rmSync(temporary, { force: true });
+    } catch {
+      // Nothing more to try; the write already failed.
+    }
+    throw error;
+  }
+}
+
+/** Persist the list atomically next to the session. Best effort only. */
+export function saveTodoTasks(
+  sessionFile: string | undefined,
+  tasks: readonly TodoTask[],
+): void {
+  try {
+    writeTodoTasks(sessionFile, tasks);
+  } catch {
+    // A failed todo write never breaks the session.
+  }
+}
+
+function assertStorable(tasks: readonly TodoTask[]): void {
+  if (tasks.length > MAX_TODOS) throw new Error(`the list holds at most ${MAX_TODOS} tasks`);
+  const seen = new Set<string>();
+  for (const task of tasks) {
+    if (!isTodoTask(task)) throw new Error("the list holds an invalid task");
+    if (seen.has(task.id)) throw new Error(`duplicate task id: ${task.id}`);
+    seen.add(task.id);
+  }
+}
+
+/** One promise chain per companion file, so writers queue instead of racing. */
+const chains = new Map<string, Promise<unknown>>();
+
+/**
+ * Serialized read-modify-write. Every mutation reads the file again inside the
+ * chain, so two parallel tool calls cannot each save a stale list and lose the
+ * other's task or push the total past the cap. A mutation that throws leaves
+ * the file exactly as it was, and so does a failed write.
+ *
+ * The chain covers this process only. Two PUM processes on one session file
+ * still race, exactly as they already do for the goal and news companions.
+ */
+export function updateTodoTasks(
+  sessionFile: string | undefined,
+  mutate: (tasks: TodoTask[]) => readonly TodoTask[],
+): Promise<TodoTask[]> {
+  // Sessionless runs share one key, which is also their one in-memory list.
+  const key = sessionFile ? todoFileFor(sessionFile) : "";
+  const previous = chains.get(key) ?? Promise.resolve();
+  const result = previous.then(() => {
+    const tasks = mutate(loadTodoTasks(sessionFile));
+    assertStorable(tasks);
+    const stored = [...tasks];
+    // Not saveTodoTasks: a caller that just added a task must hear about a
+    // failed write, or it reports success over a list that never landed.
+    writeTodoTasks(sessionFile, stored);
+    return stored;
+  });
+  // A rejection must not poison the chain, and the key goes once it drains.
+  const drained: Promise<void> = result.then(() => {}, () => {}).then(() => {
+    if (chains.get(key) === drained) chains.delete(key);
+  });
+  chains.set(key, drained);
+  return result;
+}


### PR DESCRIPTION
Builds on #21 (`feat/todo-model`), which adds `src/todo.ts`. This branch merges that PR's commit, so review only `src/todo-tools.ts` and `src/todo-tools.test.ts`; the diff shrinks to those two files once #21 lands.

Part of #12.

## What this adds

`TodoToolsController` registers five model tools against one session: `todo_list`, `todo_add`, `todo_update`, `todo_complete`, `todo_delete`. It shapes like `ToolGroupsController` — constructor, `load(sessionFile)`, `registerTool(pi)`, `extension()` — and holds no state of its own.

Nothing is wired up yet; the coordinator registers the extension and the tool group separately.

## Ownership

The controller is bound to the session it serves, so ownership never comes from tool input. No parameter names an agent, a session, an owner, or a file, which leaves a model nothing to point at another agent's list. The main agent reaches the main list, a child its own. A test asserts the schemas admit only `id`, `text` and `status`, with the right required fields and `additionalProperties: false`.

A run with no session file keeps its list in memory, and every unbound writer in the process shares that one list. Only the main agent may hold it; a child with no file of its own is told it has no list rather than being handed the main agent's. `load()` with no name unbinds, so a controller reused for a fresh run never writes to the session it served before.

## Safety

Every mutation runs through `updateTodoTasks`, so parallel calls queue instead of losing each other's work, the 100-task cap holds across them, and a rejected call leaves the companion file exactly as it was. `todo_list` is the one read and never writes, so listing an empty list creates no file.

`todo_complete` on a completed task succeeds and moves nothing, and says so: both it and `todo_update` report whether they changed anything. `todo_update` needs text, status, or both. Unknown and stale ids, and a full list, come back with the move that recovers them.

## Tests

29 tests in `src/todo-tools.test.ts`: the five contracts, idempotent completion, the "at least one change" rule, the 100-task boundary through the tool surface, unknown and stale ids leaving the file byte-identical, parallel adds all landing, two sessions staying isolated, a sessionless child getting nothing, and no tool taking an owner or a path.

`bun test` and `bunx tsc --noEmit` are clean.
