### PR TITLE
Let AFK and the goal share the input rule

### DIFF
--- a/src/animation.test.ts
+++ b/src/animation.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import type { StyledText } from "@opentui/core";
 import {
   coordinatedRuleState,
   markdownCaretContent,
@@ -147,5 +148,67 @@ describe("goal label on the working rule", () => {
     const wide = goalLabel(createGoal("模型模型模型模型", 10, 1, "g"), 60)!;
     const painted = ruleText(60, base, highlight, () => 0, { ...wide, color: "#7aa2f7" });
     expect(plainWidth(painted)).toBe(60);
+  });
+});
+
+describe("several labels on one working rule", () => {
+  const base = rgba("#292e42");
+  const highlight = rgba("#ffffff");
+  const afk = { text: "AFK · on  ", width: 10, color: "#bb9af7" };
+  const goal = { text: "GOAL · active · ship it  ", width: 25, color: "#7aa2f7" };
+  const plainWidth = (text: StyledText) =>
+    text.chunks.reduce((width, chunk) => width + Bun.stringWidth(chunk.text ?? ""), 0);
+  const painted = (text: StyledText) => text.chunks.map((chunk) => chunk.text ?? "").join("");
+
+  test("the row is exactly the rule width at every terminal size", () => {
+    for (const width of [30, 40, 80, 120]) {
+      expect(plainWidth(ruleText(width, base, highlight, () => 0, [afk, goal]))).toBe(width);
+    }
+  });
+
+  test("both labels share one row, in order, after the rule glyphs", () => {
+    const row = painted(ruleText(80, base, highlight, () => 0, [afk, goal]));
+    expect(row).toBe(`${"─".repeat(80 - afk.width - goal.width)}${afk.text}${goal.text}`);
+  });
+
+  test("each label keeps its own foreground on the shared rule background", () => {
+    const row = ruleText(80, base, highlight, () => 0, [afk, goal]);
+    const labelChunks = row.chunks.filter((chunk) => (chunk.text ?? "") !== "─");
+    expect(labelChunks.length).toBeGreaterThan(0);
+    for (const chunk of labelChunks) expect(chunk.bg).toEqual(base);
+    const foregrounds = labelChunks.map((chunk) => chunk.fg);
+    expect(foregrounds.at(0)).toEqual(rgba(afk.color));
+    expect(foregrounds.at(-1)).toEqual(rgba(goal.color));
+    expect(new Set(foregrounds.map((color) => String(color))).size).toBe(2);
+  });
+
+  test("a lone label still works, so the single-label call shape is unchanged", () => {
+    const one = ruleText(80, base, highlight, () => 0, goal);
+    expect(painted(one)).toBe(painted(ruleText(80, base, highlight, () => 0, [goal])));
+  });
+
+  test("the sweep reaches every label, so the whole row animates as one", () => {
+    const width = 80;
+    const overAfk = width - goal.width - afk.width;
+    const swept = ruleText(width, base, highlight, (c) => (c === overAfk ? 1 : 0), [afk, goal]);
+    const first = swept.chunks.find((chunk) => (chunk.text ?? "") !== "─")!;
+    expect(first.bg).not.toEqual(base);
+  });
+
+  test("a grapheme that would overflow a later label is dropped, never split", () => {
+    const narrow = [
+      { text: "AB", width: 2, color: "#bb9af7" },
+      { text: "模型", width: 4, color: "#7aa2f7" },
+    ];
+    const row = ruleText(5, base, highlight, () => 0, narrow);
+    expect(plainWidth(row)).toBe(5);
+    expect(painted(row)).toBe("AB模─");
+  });
+
+  test("animations off paints the same labels with no highlight anywhere", () => {
+    const still = ruleText(60, base, base, () => 0, [afk, goal]);
+    expect(plainWidth(still)).toBe(60);
+    expect(painted(still)).toContain(`${afk.text}${goal.text}`);
+    for (const chunk of still.chunks) expect(chunk.bg ?? base).toEqual(base);
   });
 });

--- a/src/animation.tsx
+++ b/src/animation.tsx
@@ -347,6 +347,16 @@ export type WorkingRuleLabel = {
   color: string;
 };
 
+/** One label or an ordered row of them, each keeping its own foreground. */
+export type WorkingRuleLabels = WorkingRuleLabel | readonly WorkingRuleLabel[] | null;
+
+const toLabels = (labels: WorkingRuleLabels): readonly WorkingRuleLabel[] => {
+  if (!labels) return [];
+  return Array.isArray(labels)
+    ? (labels as readonly WorkingRuleLabel[])
+    : [labels as WorkingRuleLabel];
+};
+
 const labelSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
 
 /** Highlight strength at one column, 0 when the sweep head is far away. */
@@ -368,30 +378,35 @@ const wrappedStrength = (head: number, width: number): RuleStrength => (column) 
 };
 
 /**
- * One rule row. The label sits at the right end and takes the swept rule colour
- * as its background, so the whole row animates as a single wave.
+ * One rule row. The labels sit at the right end as a group and take the swept
+ * rule colour as their background, so the whole row animates as a single wave.
  */
 export function ruleText(
   width: number,
   base: RGBA,
   hi: RGBA,
   strength: RuleStrength,
-  label: WorkingRuleLabel | null = null,
+  labels: WorkingRuleLabels = null,
 ): StyledText {
   const swept = (column: number) => {
     const value = strength(column);
     return value > 0 ? mix(base, hi, value * 0.8) : base;
   };
-  const labelWidth = label ? Math.min(label.width, width) : 0;
+  const list = toLabels(labels);
+  const labelWidth = Math.min(
+    list.reduce((total, label) => total + Math.max(0, label.width), 0),
+    width,
+  );
   const ruleColumns = Math.max(0, width - labelWidth);
   const chunks: TextChunk[] = [];
   for (let column = 0; column < ruleColumns; column++) chunks.push(fg(swept(column))("─"));
 
   let column = ruleColumns;
-  if (label) {
+  paint: for (const label of list) {
     for (const { segment } of labelSegmenter.segment(label.text)) {
       const segmentWidth = Bun.stringWidth(segment);
-      if (column + segmentWidth > width) break;
+      // Never split a grapheme across the right edge, even mid-label.
+      if (column + segmentWidth > width) break paint;
       chunks.push(bg(swept(column))(fg(label.color)(segment)));
       column += segmentWidth;
     }
@@ -409,13 +424,16 @@ export function useWorkingRule(opts: {
   active: boolean;
   mode: WorkingRuleAnimationMode;
   role: WorkingRuleRole;
-  /** Optional right-aligned label painted on the rule colour. */
-  label?: WorkingRuleLabel | null;
+  /** Optional right-aligned labels painted on the rule colour, left to right. */
+  label?: WorkingRuleLabels;
 }): RefObject<TextRenderable | null> {
   const { width, color, highlight, active, mode, role, label = null } = opts;
   const ref = useRef<TextRenderable>(null);
   const { subscribe, workingElapsed, workingRuleCycleWidth, enabled } = useClock();
-  const labelKey = label ? `${label.text}|${label.width}|${label.color}` : "";
+  // The only dependency-array proxy for the labels, so it has to cover them all.
+  const labelKey = toLabels(label)
+    .map((one) => `${one.text}|${one.width}|${one.color}`)
+    .join("\u0000");
 
   const plain = useCallback(() => {
     if (ref.current) ref.current.content = ruleText(width, rgba(color), rgba(color), STATIC_STRENGTH, label);

--- a/src/goal-line.ts
+++ b/src/goal-line.ts
@@ -6,15 +6,20 @@ import type { Theme } from "./theme";
  * The goal label that sits on the full-width rule above the prompt input.
  *
  * The rule is exactly one rendered row, so the label has to be measured in
- * terminal columns and cut on grapheme boundaries before it is painted.
+ * terminal columns and cut on grapheme boundaries before it is painted. The
+ * rule can carry more than one label, so the column budget below is shared:
+ * see `mode-line.ts`.
  */
 
-/** Columns of padding inside the label, on its right edge. */
+/** Columns of padding inside a label, on its right edge. */
 export const GOAL_LABEL_RIGHT_PADDING = 2;
+/** Separates a label's prefix, its state, and its text. */
+export const LABEL_SEPARATOR = " · ";
+/** Below this a label cannot say anything useful, so the rule stays plain. */
+export const MIN_LABEL_COLUMNS = 12;
+/** Columns of rule the labels never take, so the sweep always has somewhere to run. */
+export const MIN_RULE_COLUMNS = 4;
 const PREFIX = "GOAL";
-const SEPARATOR = " · ";
-/** Below this the label cannot say anything useful, so the rule stays plain. */
-const MIN_LABEL_COLUMNS = 12;
 
 export type GoalLabel = {
   /** Exactly what is painted, right padding included. */
@@ -36,24 +41,50 @@ export function goalLabelColor(theme: Theme, state: GoalState): string {
 }
 
 /**
- * Build the label for a rule of `ruleWidth` columns, or null when the terminal
- * is too narrow to hold one. The label never exceeds half the rule, so the
- * animated sweep always has room left.
+ * Columns every label on one rule shares, so the animated sweep always has room
+ * left. `minColumns` is the narrowest label the caller can still make useful;
+ * below it the rule stays plain.
  */
-export function goalLabel(goal: GoalRecord | null, ruleWidth: number): GoalLabel | null {
-  if (!goal || ruleWidth <= 0) return null;
-  const available = Math.min(ruleWidth, Math.max(MIN_LABEL_COLUMNS, Math.floor(ruleWidth / 2)));
-  if (available < MIN_LABEL_COLUMNS || available > ruleWidth) return null;
+export function ruleLabelBudget(ruleWidth: number, minColumns = MIN_LABEL_COLUMNS): number {
+  if (ruleWidth <= 0) return 0;
+  const room = ruleWidth - MIN_RULE_COLUMNS;
+  const budget = Math.min(room, Math.max(minColumns, Math.floor(ruleWidth / 2)));
+  return budget < minColumns ? 0 : budget;
+}
 
-  const head = `${PREFIX}${SEPARATOR}${goal.state}`;
+/** Narrowest goal label worth painting: the prefix, this state, the padding. */
+export function goalMinColumns(goal: GoalRecord): number {
+  return statusTextWidth(`${PREFIX}${LABEL_SEPARATOR}${goal.state}`) + GOAL_LABEL_RIGHT_PADDING;
+}
+
+/**
+ * Build the goal label inside `available` columns, or null when it does not
+ * fit. `includeText` off keeps only the prefix and the state.
+ */
+export function goalLabelWithin(
+  goal: GoalRecord | null,
+  available: number,
+  includeText = true,
+): GoalLabel | null {
+  if (!goal || available <= 0) return null;
+
+  const head = `${PREFIX}${LABEL_SEPARATOR}${goal.state}`;
   const padding = " ".repeat(GOAL_LABEL_RIGHT_PADDING);
   const headWidth = statusTextWidth(head) + GOAL_LABEL_RIGHT_PADDING;
   if (headWidth > available) return null;
 
-  const textColumns = available - headWidth - statusTextWidth(SEPARATOR);
+  const textColumns = available - headWidth - statusTextWidth(LABEL_SEPARATOR);
   // The rule is one row, so a multi-line goal collapses to a single line first.
   const oneLine = goal.text.replace(/\s+/g, " ").trim();
-  const text = textColumns > 0 ? truncateStatusText(oneLine, textColumns) : null;
-  const label = text ? `${head}${SEPARATOR}${text}${padding}` : `${head}${padding}`;
+  const text = includeText && textColumns > 0 ? truncateStatusText(oneLine, textColumns) : null;
+  const label = text ? `${head}${LABEL_SEPARATOR}${text}${padding}` : `${head}${padding}`;
   return { text: label, width: statusTextWidth(label), state: goal.state };
+}
+
+/**
+ * Build the label for a rule of `ruleWidth` columns, or null when the terminal
+ * is too narrow to hold one.
+ */
+export function goalLabel(goal: GoalRecord | null, ruleWidth: number): GoalLabel | null {
+  return goalLabelWithin(goal, ruleLabelBudget(ruleWidth));
 }

--- a/src/mode-line.test.ts
+++ b/src/mode-line.test.ts
@@ -97,8 +97,17 @@ describe("mode line narrow-terminal priority", () => {
     ]);
   });
 
+  test("the spare columns are shared, so neither text starves the other", () => {
+    const wordy = { state: "on", instructions: "a".repeat(300) } as const;
+    const labels = texts({ goal: goal("y".repeat(300)), afk: wordy, ruleWidth: 200 });
+    expect(labels[0]).toContain("AFK · on · aaa");
+    expect(labels[1]).toContain("GOAL · active · yyy");
+    const spread = labels.map((label) => statusTextWidth(label));
+    expect(Math.abs(spread[0]! - spread[1]!)).toBeLessThanOrEqual(10);
+  });
+
   test("the goal text goes first", () => {
-    expect(shrink(100)).toEqual(["AFK · on · prefer safe options  ", "GOAL · active  "]);
+    expect(shrink(60)).toEqual(["AFK · on · p  ", "GOAL · active  "]);
   });
 
   test("the AFK instruction preview goes next", () => {
@@ -129,11 +138,31 @@ describe("mode line narrow-terminal priority", () => {
     expect(shrink(34)).toEqual(["AFK · on  ", "GOAL · active  "]);
   });
 
-  test("a rule wide enough for the goal state never hides it for the preview", () => {
-    for (let ruleWidth = 12; ruleWidth <= 200; ruleWidth++) {
-      const labels = shrink(ruleWidth);
-      const showsPreview = labels[0]?.startsWith("AFK · on · ") ?? false;
-      if (showsPreview) expect(labels.length).toBe(2);
+  test("a narrowing rule drops in priority order and never puts anything back", () => {
+    const parts = (labels: string[]) => {
+      const afk = labels.find((label) => label.startsWith("AFK"));
+      const goal = labels.find((label) => label.startsWith("GOAL"));
+      return {
+        afkState: afk ? 1 : 0,
+        goalState: goal ? 1 : 0,
+        preview: afk && afk.split(" · ").length > 2 ? 1 : 0,
+        goalText: goal && goal.split(" · ").length > 2 ? 1 : 0,
+      };
+    };
+    for (const instructions of ["prefer safe options", "a".repeat(300)]) {
+      for (const text of ["ship the release", "模型".repeat(80)]) {
+        let previous = parts([]);
+        for (let ruleWidth = 0; ruleWidth <= 300; ruleWidth++) {
+          const now = parts(texts({ goal: goal(text), afk: { state: "on", instructions }, ruleWidth }));
+          for (const key of ["afkState", "goalState", "preview", "goalText"] as const) {
+            expect(now[key]).toBeGreaterThanOrEqual(previous[key]);
+          }
+          // The goal state outranks the preview, which outranks the goal text.
+          if (now.preview) expect(now.goalState).toBe(1);
+          if (now.goalText) expect(now.preview).toBe(1);
+          previous = now;
+        }
+      }
     }
   });
 });

--- a/src/mode-line.test.ts
+++ b/src/mode-line.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, test } from "bun:test";
+import { AFK_RULE_STATES, afkLabelColor, modeLineLabels, type AfkRuleState } from "./mode-line";
+import {
+  GOAL_LABEL_RIGHT_PADDING,
+  MIN_RULE_COLUMNS,
+  goalLabel,
+  goalLabelColor,
+} from "./goal-line";
+import { createGoal, type GoalRecord, type GoalState } from "./goal";
+import { statusTextWidth } from "./status-metadata";
+import { PRESET_NAMES, loadTheme } from "./theme";
+
+const theme = loadTheme("tokyonight");
+
+function goal(text = "ship the release", state: GoalState = "active"): GoalRecord {
+  return { ...createGoal(text, 10, 1, "goal-1"), state };
+}
+
+const on: AfkRuleState = { state: "on", instructions: "prefer safe options" };
+
+const texts = (input: {
+  goal?: GoalRecord | null;
+  afk?: AfkRuleState | null;
+  ruleWidth: number;
+}) =>
+  modeLineLabels({
+    goal: input.goal ?? null,
+    afk: input.afk ?? null,
+    ruleWidth: input.ruleWidth,
+    theme,
+  }).map((label) => label.text);
+
+const totalWidth = (input: { goal: GoalRecord | null; afk: AfkRuleState | null; ruleWidth: number }) =>
+  modeLineLabels({ ...input, theme }).reduce((sum, label) => sum + label.width, 0);
+
+describe("mode line labels", () => {
+  test("a goal alone is exactly the label the goal rule already painted", () => {
+    for (let ruleWidth = 0; ruleWidth <= 200; ruleWidth++) {
+      const expected = goalLabel(goal(), ruleWidth);
+      const labels = modeLineLabels({ goal: goal(), afk: null, ruleWidth, theme });
+      expect(labels.map((label) => label.text)).toEqual(expected ? [expected.text] : []);
+      if (expected) expect(labels[0]!.color).toBe(goalLabelColor(theme, "active"));
+    }
+  });
+
+  test("AFK and the goal share one row, AFK first, each with its own colour", () => {
+    const labels = modeLineLabels({ goal: goal(), afk: on, ruleWidth: 200, theme });
+    expect(labels).toHaveLength(2);
+    expect(labels[0]!.text).toBe("AFK · on · prefer safe options  ");
+    expect(labels[1]!.text).toBe("GOAL · active · ship the release  ");
+    expect(labels[0]!.color).toBe(afkLabelColor(theme, "on"));
+    expect(labels[1]!.color).toBe(goalLabelColor(theme, "active"));
+    expect(labels[0]!.color).not.toBe(labels[1]!.color);
+  });
+
+  test("every label reports its own rendered width", () => {
+    for (const label of modeLineLabels({ goal: goal(), afk: on, ruleWidth: 200, theme })) {
+      expect(label.width).toBe(statusTextWidth(label.text));
+    }
+  });
+
+  test("the last label ends with exactly two columns of right padding", () => {
+    for (const ruleWidth of [200, 100, 56, 28]) {
+      const labels = modeLineLabels({ goal: goal(), afk: on, ruleWidth, theme });
+      const last = labels.at(-1)!;
+      expect(last.text.endsWith(" ".repeat(GOAL_LABEL_RIGHT_PADDING))).toBe(true);
+      expect(last.text.at(-GOAL_LABEL_RIGHT_PADDING - 1)).not.toBe(" ");
+    }
+  });
+
+  test("the labels always leave the sweep some rule to run on", () => {
+    for (let ruleWidth = 0; ruleWidth <= 200; ruleWidth++) {
+      for (const afk of [null, on, { state: "answering" } as const]) {
+        for (const text of ["ship it", "x".repeat(400), "模型".repeat(50)]) {
+          const width = totalWidth({ goal: goal(text), afk, ruleWidth });
+          if (width > 0) expect(width).toBeLessThanOrEqual(ruleWidth - MIN_RULE_COLUMNS);
+        }
+      }
+    }
+  });
+
+  test("a goal alone never takes more than half the rule", () => {
+    for (const ruleWidth of [24, 40, 80, 120, 200]) {
+      const width = totalWidth({ goal: goal("x".repeat(400)), afk: null, ruleWidth });
+      expect(width).toBeLessThanOrEqual(Math.floor(ruleWidth / 2));
+    }
+  });
+});
+
+describe("mode line narrow-terminal priority", () => {
+  const shrink = (ruleWidth: number) => texts({ goal: goal(), afk: on, ruleWidth });
+
+  test("a wide rule shows both states, the instructions, and the goal text", () => {
+    expect(shrink(200)).toEqual([
+      "AFK · on · prefer safe options  ",
+      "GOAL · active · ship the release  ",
+    ]);
+  });
+
+  test("the goal text goes first", () => {
+    expect(shrink(100)).toEqual(["AFK · on · prefer safe options  ", "GOAL · active  "]);
+  });
+
+  test("the AFK instruction preview goes next", () => {
+    expect(shrink(56)).toEqual(["AFK · on  ", "GOAL · active  "]);
+  });
+
+  test("the goal goes next, and takes the preview with it", () => {
+    expect(shrink(28)).toEqual(["AFK · on  "]);
+  });
+
+  test("nothing is painted only when no useful label fits", () => {
+    expect(shrink(12)).toEqual([]);
+    expect(shrink(0)).toEqual([]);
+    expect(texts({ ruleWidth: 200 })).toEqual([]);
+    expect(texts({ afk: { state: "answering" }, ruleWidth: 16 })).toEqual([]);
+  });
+
+  test("each step keeps AFK and its state, whatever else it drops", () => {
+    for (let ruleWidth = 12; ruleWidth <= 200; ruleWidth++) {
+      const labels = shrink(ruleWidth);
+      if (labels.length === 0) continue;
+      expect(labels[0]!.startsWith("AFK · on")).toBe(true);
+    }
+  });
+
+  test("both states share the rule rather than one losing to half-rule budget", () => {
+    // 34 columns is under twice the two states, so a strict half would drop one.
+    expect(shrink(34)).toEqual(["AFK · on  ", "GOAL · active  "]);
+  });
+
+  test("a rule wide enough for the goal state never hides it for the preview", () => {
+    for (let ruleWidth = 12; ruleWidth <= 200; ruleWidth++) {
+      const labels = shrink(ruleWidth);
+      const showsPreview = labels[0]?.startsWith("AFK · on · ") ?? false;
+      if (showsPreview) expect(labels.length).toBe(2);
+    }
+  });
+});
+
+describe("mode line label text", () => {
+  test("collapses multi-line AFK instructions to one line", () => {
+    const labels = texts({
+      afk: { state: "on", instructions: "first line\n\n  second line" },
+      ruleWidth: 200,
+    });
+    expect(labels[0]).not.toContain("\n");
+    expect(labels[0]).toContain("first line second line");
+  });
+
+  test("truncates instructions by terminal columns without splitting a grapheme", () => {
+    const labels = modeLineLabels({
+      goal: null,
+      afk: { state: "on", instructions: "模型模型模型模型模型模型" },
+      ruleWidth: 40,
+      theme,
+    });
+    expect(labels[0]!.width).toBe(statusTextWidth(labels[0]!.text));
+    expect(labels[0]!.text).toContain("…");
+    const combining = texts({
+      afk: { state: "on", instructions: "éclair éclair éclair éclair" },
+      ruleWidth: 40,
+    });
+    expect(combining[0]).not.toContain("́…");
+  });
+
+  test("no instructions means no preview, whatever the width", () => {
+    expect(texts({ afk: { state: "on" }, ruleWidth: 200 })).toEqual(["AFK · on  "]);
+    expect(texts({ afk: { state: "answering", instructions: "" }, ruleWidth: 200 })).toEqual([
+      "AFK · answering  ",
+    ]);
+  });
+
+  test("every AFK state names itself", () => {
+    for (const state of AFK_RULE_STATES) {
+      expect(texts({ afk: { state }, ruleWidth: 200 })[0]).toBe(`AFK · ${state}  `);
+    }
+  });
+
+  test("every goal state still names itself beside AFK", () => {
+    for (const state of ["active", "stopped", "blocked", "completed", "failed"] as const) {
+      const labels = texts({ goal: goal("ship it", state), afk: { state: "on" }, ruleWidth: 200 });
+      expect(labels[1]).toContain(`· ${state} ·`);
+    }
+  });
+});
+
+describe("AFK label colour", () => {
+  test("uses a semantic token per state in every preset", () => {
+    for (const name of PRESET_NAMES) {
+      const preset = loadTheme(name);
+      expect(afkLabelColor(preset, "on")).toBe(preset.agentMessage);
+      expect(afkLabelColor(preset, "answering")).toBe(preset.statsRunning);
+    }
+  });
+
+  test("no preset paints AFK in the rule colour it sits on", () => {
+    for (const name of PRESET_NAMES) {
+      const preset = loadTheme(name);
+      for (const state of AFK_RULE_STATES) {
+        expect(afkLabelColor(preset, state)).not.toBe(preset.border);
+        expect(afkLabelColor(preset, state)).not.toBe(preset.dim);
+      }
+    }
+  });
+});

--- a/src/mode-line.ts
+++ b/src/mode-line.ts
@@ -34,6 +34,9 @@ export type AfkRuleState = {
   instructions?: string | null;
 };
 
+/** A preview needs the separator and a column of text to say anything at all. */
+const MIN_PREVIEW_COLUMNS = statusTextWidth(LABEL_SEPARATOR) + 1;
+
 /** Narrowest AFK label worth painting: the prefix, this state, the padding. */
 const afkMinColumns = (afk: AfkRuleState): number =>
   statusTextWidth(`${PREFIX}${LABEL_SEPARATOR}${afk.state}`) + GOAL_LABEL_RIGHT_PADDING;
@@ -105,8 +108,6 @@ export function modeLineLabels(input: ModeLineInput): WorkingRuleLabel[] {
   let left = budget;
 
   let afkPainted = afk ? afkLabel(afk, left, 0) : null;
-  // The budget already reserves the state, so this only satisfies the compiler.
-  if (afk && !afkPainted) return [];
   if (afkPainted) left -= afkPainted.width;
 
   let goalPainted = goal ? goalLabelWithin(goal, left, false) : null;
@@ -116,10 +117,15 @@ export function modeLineLabels(input: ModeLineInput): WorkingRuleLabel[] {
   // both, a stub of a preview is noise, so the goal takes it down with it.
   const goalSqueezedOut = goal !== null && goalPainted === null;
   if (afk && afkPainted && !goalSqueezedOut) {
-    const room = afkPainted.width + left;
+    // Long instructions would otherwise eat every spare column and the goal
+    // would never say what it is. Half the spare is the preview's, but it keeps
+    // its own minimum, so the goal text is the first of the two to run out.
+    const share = Math.max(MIN_PREVIEW_COLUMNS, Math.ceil(left / 2));
+    const spare = goalPainted ? Math.min(left, share) : left;
+    const room = afkPainted.width + spare;
     const withPreview = afkLabel(afk, room, room);
     if (withPreview) {
-      left = room - withPreview.width;
+      left -= withPreview.width - afkPainted.width;
       afkPainted = withPreview;
     }
   }

--- a/src/mode-line.ts
+++ b/src/mode-line.ts
@@ -1,0 +1,141 @@
+import {
+  GOAL_LABEL_RIGHT_PADDING,
+  LABEL_SEPARATOR,
+  MIN_LABEL_COLUMNS,
+  goalLabelColor,
+  goalLabelWithin,
+  goalMinColumns,
+  ruleLabelBudget,
+} from "./goal-line";
+import { statusTextWidth, truncateStatusText } from "./status-metadata";
+import type { WorkingRuleLabel } from "./animation";
+import type { GoalRecord } from "./goal";
+import type { Theme } from "./theme";
+
+/**
+ * The labels that share the full-width rule above the prompt input.
+ *
+ * AFK sits left of the goal, because the rule clips at its right edge: when the
+ * terminal is too narrow for everything, the goal loses columns first.
+ */
+
+const PREFIX = "AFK";
+
+export type AfkRuleStateName = "on" | "answering";
+export const AFK_RULE_STATES: readonly AfkRuleStateName[] = ["on", "answering"];
+
+/**
+ * All the rule needs to know about AFK. The controller owns the real state;
+ * this stays a plain value so the label builder has no dependency on it.
+ */
+export type AfkRuleState = {
+  state: AfkRuleStateName;
+  /** Current AFK guidance, previewed when the rule has columns to spare. */
+  instructions?: string | null;
+};
+
+/** Narrowest AFK label worth painting: the prefix, this state, the padding. */
+const afkMinColumns = (afk: AfkRuleState): number =>
+  statusTextWidth(`${PREFIX}${LABEL_SEPARATOR}${afk.state}`) + GOAL_LABEL_RIGHT_PADDING;
+
+/** Foreground for the AFK label, by what AFK is doing. */
+export function afkLabelColor(theme: Theme, state: AfkRuleStateName): string {
+  return state === "answering" ? theme.statsRunning : theme.agentMessage;
+}
+
+/**
+ * Build the AFK label inside `available` columns. `previewAllowance` caps the
+ * whole label when the instruction preview is wanted; 0 leaves it out.
+ */
+function afkLabel(
+  afk: AfkRuleState,
+  available: number,
+  previewAllowance: number,
+): { text: string; width: number } | null {
+  if (available <= 0) return null;
+
+  const head = `${PREFIX}${LABEL_SEPARATOR}${afk.state}`;
+  const padding = " ".repeat(GOAL_LABEL_RIGHT_PADDING);
+  const headWidth = statusTextWidth(head) + GOAL_LABEL_RIGHT_PADDING;
+  if (headWidth > available) return null;
+
+  const textColumns =
+    Math.min(available, previewAllowance) - headWidth - statusTextWidth(LABEL_SEPARATOR);
+  // The rule is one row, so multi-line instructions collapse to one line first.
+  const oneLine = (afk.instructions ?? "").replace(/\s+/g, " ").trim();
+  const preview = oneLine && textColumns > 0 ? truncateStatusText(oneLine, textColumns) : null;
+  const text = preview ? `${head}${LABEL_SEPARATOR}${preview}${padding}` : `${head}${padding}`;
+  return { text, width: statusTextWidth(text) };
+}
+
+export type ModeLineInput = {
+  goal: GoalRecord | null;
+  afk: AfkRuleState | null;
+  ruleWidth: number;
+  theme: Theme;
+};
+
+/**
+ * Columns the labels may share. AFK and the goal both outrank anything
+ * optional, so a rule that can seat both states widens past half the rule to do
+ * it, and only falls back to AFK alone when even that does not fit.
+ */
+function labelBudget(ruleWidth: number, afk: AfkRuleState | null, goal: GoalRecord | null): number {
+  if (!afk) return ruleLabelBudget(ruleWidth);
+  if (goal) {
+    const both = ruleLabelBudget(ruleWidth, afkMinColumns(afk) + goalMinColumns(goal));
+    if (both > 0) return both;
+  }
+  return ruleLabelBudget(ruleWidth, Math.max(MIN_LABEL_COLUMNS, afkMinColumns(afk)));
+}
+
+/**
+ * The ordered labels for a rule of `ruleWidth` columns, empty when the terminal
+ * cannot show a useful minimum. Together they never take more than the shared
+ * budget, so the animated sweep always has rule left to run on.
+ *
+ * Columns go out in priority order — the AFK state, the goal state, the AFK
+ * instruction preview, then the goal text — so a narrowing rule loses the goal
+ * text first and the AFK state last.
+ */
+export function modeLineLabels(input: ModeLineInput): WorkingRuleLabel[] {
+  const { goal, afk, theme } = input;
+  const budget = labelBudget(input.ruleWidth, afk, goal);
+  if (budget <= 0) return [];
+  let left = budget;
+
+  let afkPainted = afk ? afkLabel(afk, left, 0) : null;
+  // The budget already reserves the state, so this only satisfies the compiler.
+  if (afk && !afkPainted) return [];
+  if (afkPainted) left -= afkPainted.width;
+
+  let goalPainted = goal ? goalLabelWithin(goal, left, false) : null;
+  if (goalPainted) left -= goalPainted.width;
+
+  // The goal state outranks the preview. When the rule is too narrow to seat
+  // both, a stub of a preview is noise, so the goal takes it down with it.
+  const goalSqueezedOut = goal !== null && goalPainted === null;
+  if (afk && afkPainted && !goalSqueezedOut) {
+    const room = afkPainted.width + left;
+    const withPreview = afkLabel(afk, room, room);
+    if (withPreview) {
+      left = room - withPreview.width;
+      afkPainted = withPreview;
+    }
+  }
+
+  if (goal && goalPainted) {
+    goalPainted = goalLabelWithin(goal, goalPainted.width + left, true) ?? goalPainted;
+  }
+
+  const labels: WorkingRuleLabel[] = [];
+  if (afk && afkPainted) labels.push({ ...afkPainted, color: afkLabelColor(theme, afk.state) });
+  if (goalPainted) {
+    labels.push({
+      text: goalPainted.text,
+      width: goalPainted.width,
+      color: goalLabelColor(theme, goalPainted.state),
+    });
+  }
+  return labels;
+}


### PR DESCRIPTION
Part of #14: the input rule now carries more than one label.

## What changed

**`src/animation.tsx`** — `ruleText` takes an ordered list of labels instead of
one and paints them as a single right-aligned group on the shared swept
background, each keeping its own foreground. A lone label still works, so
`app.tsx`'s current call site compiles unchanged. `labelKey` in `useWorkingRule`
now covers every label, so the frame effect re-runs when any of them changes.

Both invariants the tests pin survive: the row is exactly `width` columns, and a
grapheme that would cross the right edge is dropped rather than split — now
across a label boundary as well as at the end of one.

**`src/mode-line.ts`** (new) — turns the goal and a plain AFK value into that
list. AFK sits left of the goal, because the rule clips at its right edge.
Columns go out in the priority order the issue asks for:

1. the AFK state,
2. the goal state,
3. the AFK instruction preview,
4. the goal text.

So a narrowing rule loses the goal text first, then the preview, then the goal,
and hides everything only when no useful label fits — checked as a monotonicity
property over widths 0 to 300. The preview and the goal text split the spare
columns, so long instructions cannot starve the goal. The labels always leave at
least four columns of rule for the sweep. Instructions collapse to one line,
truncate by terminal columns, and keep two columns of right padding after the
final label. Colours come from semantic theme tokens: `agentMessage` for
`AFK · on`, `statsRunning` for `AFK · answering`.

**`src/goal-line.ts`** — the "never more than half the rule" budget became
`ruleLabelBudget`, shared across labels, and `goalLabel` is now a thin wrapper
over `goalLabelWithin`. With no AFK the output is the goal label the rule
already painted, column for column: checked against the previous implementation
for every goal state, seven text shapes, and every width from 0 to 400.

## Not in this PR

Nothing produces an `AfkRuleState` yet and `app.tsx` still passes a single
label — the AFK controller and the `app.tsx` wiring are other units of #14.

## Verification

`bun test` and `bunx tsc --noEmit` are clean. Two suite failures
(`prompt input layout`, `subagent transcript UI`) reproduce on a clean checkout
of `main` in this worktree: the long branch name overflows the status bar.
