### PR TITLE
Add the view-only Todo popup

### DIFF
--- a/src/todo-popup.test.tsx
+++ b/src/todo-popup.test.tsx
@@ -1,0 +1,290 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createTestRenderer } from "@opentui/core/testing";
+import { createRoot } from "@opentui/react";
+import {
+  cycleTodoFilter,
+  moveTodoSelection,
+  TODO_FILTERS,
+  todoEmptyLines,
+  todoFooterText,
+  todoPopupLayout,
+  TodoPopup,
+  todoStatusSummary,
+  visibleTodoTasks,
+  type TodoFilter,
+} from "./todo-popup";
+import { createTodoTask, type TodoStatus, type TodoTask } from "./todo";
+import { loadTheme } from "./theme";
+
+const NOW = 1_700_000_000_000;
+
+function task(id: string, text: string, status: TodoStatus, minutesOld = 0): TodoTask {
+  const at = NOW - minutesOld * 60_000;
+  return { ...createTodoTask(text, status, at, id), updatedAt: at };
+}
+
+const TASKS: TodoTask[] = [
+  task("aaa111", "Write the parser", "pending", 30),
+  task("bbb222", "Ship the release", "active", 90),
+  task("ccc333", "Wait on review", "blocked", 20),
+  task("ddd444", "Delete dead code", "completed", 10),
+  task("eee555", "Drop the old flag", "cancelled", 5),
+  task("fff666", "Write the printer", "pending", 15),
+];
+
+let destroy: (() => void) | undefined;
+afterEach(() => destroy?.());
+
+async function renderTodo(options: {
+  width: number;
+  height: number;
+  tasks?: readonly TodoTask[];
+  filter?: TodoFilter;
+  selectedId?: string | null;
+  agentName?: string;
+}) {
+  const { width, height } = options;
+  const setup = await createTestRenderer({ width, height });
+  destroy = () => setup.renderer.destroy();
+  createRoot(setup.renderer).render(
+    <box style={{ width, height }}>
+      <TodoPopup
+        theme={loadTheme("tokyonight")}
+        terminalWidth={width}
+        terminalHeight={height}
+        agentName={options.agentName ?? "Nomad"}
+        tasks={options.tasks ?? TASKS}
+        filter={options.filter ?? "all"}
+        selectedId={options.selectedId === undefined ? "bbb222" : options.selectedId}
+        now={NOW}
+      />
+    </box>,
+  );
+  await setup.renderOnce();
+  await setup.flush();
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  await setup.renderOnce();
+  await setup.flush();
+  return setup.captureCharFrame();
+}
+
+describe("todo ordering and filtering", () => {
+  test("orders by canonical status, then age, then id", () => {
+    const order = visibleTodoTasks(TASKS, "all").map((entry) => entry.id);
+    expect(order).toEqual(["bbb222", "aaa111", "fff666", "ccc333", "ddd444", "eee555"]);
+  });
+
+  test("each filter keeps only its own status", () => {
+    for (const filter of TODO_FILTERS) {
+      const visible = visibleTodoTasks(TASKS, filter);
+      if (filter === "all") {
+        expect(visible).toHaveLength(TASKS.length);
+        continue;
+      }
+      expect(visible).toHaveLength(TASKS.filter((entry) => entry.status === filter).length);
+      expect(visible.length).toBeGreaterThan(0);
+      expect(visible.every((entry) => entry.status === filter)).toBe(true);
+    }
+  });
+
+  test("the filter cycle wraps through every status", () => {
+    let filter: TodoFilter = "all";
+    const seen: TodoFilter[] = [filter];
+    for (let step = 0; step < TODO_FILTERS.length - 1; step += 1) {
+      filter = cycleTodoFilter(filter);
+      seen.push(filter);
+    }
+    expect(seen).toEqual([...TODO_FILTERS]);
+    expect(cycleTodoFilter(filter)).toBe("all");
+  });
+
+  test("summarizes the counts it holds", () => {
+    expect(todoStatusSummary(TASKS)).toBe(
+      "1 active · 2 pending · 1 blocked · 1 completed · 1 cancelled",
+    );
+    expect(todoStatusSummary([])).toBe("no tasks");
+  });
+});
+
+describe("todo selection", () => {
+  const visible = visibleTodoTasks(TASKS, "all");
+
+  test("steps forward and back", () => {
+    expect(moveTodoSelection(visible, "bbb222", 1)).toBe("aaa111");
+    expect(moveTodoSelection(visible, "aaa111", -1)).toBe("bbb222");
+  });
+
+  test("wraps at both ends", () => {
+    expect(moveTodoSelection(visible, "eee555", 1)).toBe("bbb222");
+    expect(moveTodoSelection(visible, "bbb222", -1)).toBe("eee555");
+  });
+
+  test("a lost selection lands on the near end", () => {
+    expect(moveTodoSelection(visible, null, 1)).toBe("bbb222");
+    expect(moveTodoSelection(visible, "gone", -1)).toBe("eee555");
+  });
+
+  test("an empty list has nothing to select", () => {
+    expect(moveTodoSelection([], null, 1)).toBeNull();
+    expect(moveTodoSelection([], "bbb222", -1)).toBeNull();
+  });
+});
+
+describe("todo layout", () => {
+  test("keeps the footer and a task row on a short terminal", () => {
+    for (const height of [8, 10, 14, 24]) {
+      const layout = todoPopupLayout(80, height);
+      expect(layout.footerHeight).toBe(1);
+      expect(layout.listHeight).toBeGreaterThanOrEqual(1);
+      const rows = layout.listHeight + layout.separatorHeight +
+        layout.summaryHeight + layout.footerHeight;
+      expect(rows).toBe(layout.popupHeight - 4);
+    }
+  });
+
+  test("drops the separator before the summary as height shrinks", () => {
+    const tall = todoPopupLayout(80, 40);
+    expect(tall.separatorHeight).toBe(1);
+    expect(tall.summaryHeight).toBe(1);
+    const short = todoPopupLayout(80, 9);
+    expect(short.separatorHeight).toBe(0);
+  });
+
+  test("never covers the terminal row the shadow needs", () => {
+    for (const height of [3, 6, 12, 30, 60]) {
+      const layout = todoPopupLayout(80, height);
+      expect(layout.top + layout.popupHeight).toBeLessThan(height);
+    }
+  });
+
+  test("row columns always sum to the content width", () => {
+    for (let width = 4; width <= 200; width += 1) {
+      const layout = todoPopupLayout(width, 24);
+      const columns = layout.markerWidth + layout.glyphWidth + layout.textWidth +
+        layout.idWidth + layout.ageWidth;
+      expect(columns).toBeLessThanOrEqual(Math.max(layout.contentWidth, 1));
+      expect(layout.margin * 2 + layout.popupWidth).toBeLessThanOrEqual(width);
+    }
+  });
+
+  test("the footer fits and keeps the close hint at every width", () => {
+    for (let width = 30; width <= 200; width += 1) {
+      for (const filter of TODO_FILTERS) {
+        const layout = todoPopupLayout(width, 24);
+        const footer = todoFooterText(layout, filter, 2, 6);
+        expect(Bun.stringWidth(footer)).toBeLessThanOrEqual(layout.contentWidth);
+        expect(footer).toContain("esc");
+        expect(footer).toContain("2/6");
+      }
+    }
+  });
+});
+
+describe("todo popup rendering", () => {
+  test("shows the agent, the tasks, their ids and ages", async () => {
+    const frame = await renderTodo({ width: 80, height: 24 });
+    expect(frame).toContain("Nomad");
+    expect(frame).toContain("Ship the release");
+    expect(frame).toContain("Write the parser");
+    expect(frame).toContain("bbb222");
+    expect(frame).toContain("1h ago");
+    expect(frame).toContain("filter all");
+    expect(frame).toContain("1/6");
+  });
+
+  test("two tasks with similar text stay apart by id", async () => {
+    const frame = await renderTodo({ width: 80, height: 24, filter: "pending" });
+    expect(frame).toContain("Write the parser");
+    expect(frame).toContain("Write the printer");
+    expect(frame).toContain("aaa111");
+    expect(frame).toContain("fff666");
+  });
+
+  test("a filter narrows the list and the footer total", async () => {
+    const frame = await renderTodo({
+      width: 80,
+      height: 24,
+      filter: "completed",
+      selectedId: "ddd444",
+    });
+    expect(frame).toContain("Delete dead code");
+    expect(frame).not.toContain("Ship the release");
+    expect(frame).toContain("filter completed");
+    expect(frame).toContain("1/1");
+  });
+
+  test("the empty state points at enable_tools and Todo", async () => {
+    const frame = await renderTodo({
+      width: 80,
+      height: 24,
+      tasks: [],
+      selectedId: null,
+      agentName: "Vega",
+    });
+    expect(frame).toContain("Vega has no tasks yet");
+    // The whole instruction, not just the word Todo in the popup title.
+    expect(frame).toContain("Vega can call enable_tools with Todo, then todo_add.");
+    expect(frame).toContain("read-only");
+  });
+
+  test("an empty filter says how to change it", async () => {
+    const frame = await renderTodo({
+      width: 80,
+      height: 24,
+      tasks: [TASKS[0] as TodoTask],
+      filter: "blocked",
+      selectedId: null,
+    });
+    expect(frame).toContain("No blocked tasks");
+    expect(frame).toContain("change the filter");
+  });
+
+  test("long text truncates with an ellipsis, never a split grapheme", async () => {
+    const long = task("ggg777", `${"👨‍👩‍👧‍👦".repeat(40)} tail`, "active");
+    const frame = await renderTodo({
+      width: 80,
+      height: 24,
+      tasks: [long],
+      selectedId: "ggg777",
+    });
+    expect(frame).toContain("…");
+    expect(frame).not.toContain("tail");
+    for (const line of frame.split("\n")) {
+      expect(Bun.stringWidth(line)).toBeLessThanOrEqual(80);
+    }
+  });
+
+  test("a narrow terminal keeps the footer and stays inside the width", async () => {
+    const frame = await renderTodo({ width: 34, height: 12 });
+    const lines = frame.split("\n");
+    for (const line of lines) expect(Bun.stringWidth(line)).toBeLessThanOrEqual(34);
+    expect(frame).toContain("esc");
+    expect(frame).toContain("1/6");
+  });
+
+  test("a short terminal still paints a row and the footer", async () => {
+    const frame = await renderTodo({ width: 80, height: 9 });
+    expect(frame).toContain("Ship the release");
+    expect(frame).toContain("esc close");
+    expect(frame.split("\n").length).toBeLessThanOrEqual(10);
+  });
+
+  test("the visible window follows the selection down the list", async () => {
+    const frame = await renderTodo({ width: 80, height: 10, selectedId: "eee555" });
+    expect(frame).toContain("Drop the old flag");
+    expect(frame).not.toContain("Ship the release");
+  });
+
+  test("a mid-list selection still shows the rows after it", async () => {
+    const frame = await renderTodo({ width: 80, height: 12, selectedId: "ccc333" });
+    expect(frame).toContain("Wait on review");
+    // Anchoring the selection to the last visible row would hide these.
+    expect(frame).toContain("Delete dead code");
+  });
+
+  test("the empty-state lines never spill past the list", () => {
+    const layout = todoPopupLayout(80, 9);
+    const lines = todoEmptyLines("Vega", "all", false);
+    expect(lines.length).toBeGreaterThan(layout.listHeight);
+  });
+});

--- a/src/todo-popup.tsx
+++ b/src/todo-popup.tsx
@@ -1,0 +1,350 @@
+import type { Theme } from "./theme";
+import { PopupFrame } from "./popup-frame";
+import { sortTodoTasks, TODO_STATUSES, type TodoStatus, type TodoTask } from "./todo";
+import { statusTextWidth, truncateStatusText } from "./status-metadata";
+import { formatAge } from "./news";
+
+/**
+ * The view-only todo popup.
+ *
+ * It owns layout and nothing else. Every key that drives it belongs to the
+ * single useKeyboard in app.tsx, and only the Todo tools ever change a task.
+ */
+
+export type TodoFilter = "all" | TodoStatus;
+
+/**
+ * Cycle order for the `f` key: "all" first so a fresh popup shows everything,
+ * then the canonical status order, so a new status joins the cycle by itself.
+ */
+export const TODO_FILTERS: readonly TodoFilter[] = ["all", ...TODO_STATUSES];
+
+export function cycleTodoFilter(current: TodoFilter): TodoFilter {
+  const at = TODO_FILTERS.indexOf(current);
+  return TODO_FILTERS[(at + 1) % TODO_FILTERS.length]!;
+}
+
+/**
+ * The rows the popup paints, in canonical order. app.tsx moves the selection
+ * over this same list, so the key handler and the paint can never disagree.
+ */
+export function visibleTodoTasks(
+  tasks: readonly TodoTask[],
+  filter: TodoFilter,
+): TodoTask[] {
+  const matching = filter === "all" ? tasks : tasks.filter((task) => task.status === filter);
+  return sortTodoTasks(matching);
+}
+
+/** Wrapping move over the visible rows. Null when there is nothing to select. */
+export function moveTodoSelection(
+  tasks: readonly TodoTask[],
+  selectedId: string | null,
+  step: -1 | 1,
+): string | null {
+  if (tasks.length === 0) return null;
+  const current = tasks.findIndex((task) => task.id === selectedId);
+  // A lost selection lands on the first row going down, the last going up.
+  const start = current < 0 ? (step > 0 ? -1 : 0) : current;
+  return tasks[(start + step + tasks.length) % tasks.length]!.id;
+}
+
+export type TodoPopupLayout = {
+  narrow: boolean;
+  margin: number;
+  popupWidth: number;
+  popupHeight: number;
+  top: number;
+  /** Columns inside the border and padding. Every row column sums to this. */
+  contentWidth: number;
+  markerWidth: number;
+  glyphWidth: number;
+  idWidth: number;
+  ageWidth: number;
+  textWidth: number;
+  summaryHeight: number;
+  separatorHeight: number;
+  listHeight: number;
+  footerHeight: number;
+};
+
+const TODO_POPUP_FRAME_ROWS = 4;
+const TODO_POPUP_MIN_HEIGHT = 8;
+const TODO_POPUP_MAX_HEIGHT = 28;
+const TODO_POPUP_HEIGHT_RATIO = 0.8;
+
+/** Short id shown beside the text so two similar tasks stay distinguishable. */
+const TODO_ID_LENGTH = 7;
+
+export function todoPopupLayout(terminalWidth: number, terminalHeight: number): TodoPopupLayout {
+  const narrow = terminalWidth < 64;
+  const margin = terminalWidth < 4 ? 0 : narrow ? 1 : Math.max(2, Math.floor(terminalWidth * 0.1));
+  const popupWidth = Math.max(1, terminalWidth - margin * 2);
+  const scaledHeight = Math.floor(terminalHeight * TODO_POPUP_HEIGHT_RATIO);
+  const desiredHeight = Math.max(
+    TODO_POPUP_MIN_HEIGHT,
+    Math.min(TODO_POPUP_MAX_HEIGHT, scaledHeight),
+  );
+  // Reserve the final terminal row for PopupFrame's bottom shadow.
+  const availableHeight = Math.max(1, terminalHeight - (terminalHeight > 1 ? 1 : 0));
+  const popupHeight = Math.min(availableHeight, desiredHeight);
+  const top = Math.max(0, Math.floor((terminalHeight - popupHeight) / 2));
+  const innerHeight = Math.max(0, popupHeight - TODO_POPUP_FRAME_ROWS);
+
+  const footerHeight = innerHeight >= 2 ? 1 : 0;
+  const minimumListHeight = innerHeight >= 1 ? 1 : 0;
+  const optionalRows = Math.max(0, innerHeight - footerHeight - minimumListHeight);
+  const summaryHeight = optionalRows >= 2 ? 1 : 0;
+  const separatorHeight = optionalRows >= 3 ? 1 : 0;
+  const listHeight = Math.max(
+    0,
+    innerHeight - footerHeight - summaryHeight - separatorHeight,
+  );
+
+  // Border and padding take one column on each side.
+  const contentWidth = Math.max(1, popupWidth - 4);
+  const markerWidth = contentWidth >= 12 ? 2 : 0;
+  const glyphWidth = contentWidth >= 4 ? 2 : 0;
+  const idWidth = contentWidth >= 32 ? TODO_ID_LENGTH + 1 : 0;
+  const ageWidth = contentWidth >= 44 ? 9 : 0;
+  const textWidth = Math.max(
+    1,
+    contentWidth - markerWidth - glyphWidth - idWidth - ageWidth,
+  );
+
+  return {
+    narrow,
+    margin,
+    popupWidth,
+    popupHeight,
+    top,
+    contentWidth,
+    markerWidth,
+    glyphWidth,
+    idWidth,
+    ageWidth,
+    textWidth,
+    summaryHeight,
+    separatorHeight,
+    listHeight,
+    footerHeight,
+  };
+}
+
+/** A glyph, not colour alone, carries the status where colour cannot. */
+const STATUS_GLYPHS: Record<TodoStatus, string> = {
+  active: "▶",
+  pending: "○",
+  blocked: "!",
+  completed: "✓",
+  cancelled: "✗",
+};
+
+function statusColor(theme: Theme, status: TodoStatus): string {
+  switch (status) {
+    case "active": return theme.accent;
+    case "blocked": return theme.warn;
+    case "completed": return theme.success;
+    case "cancelled": return theme.dim;
+    default: return theme.fg;
+  }
+}
+
+/** Cut to rendered columns without splitting a grapheme. */
+function fit(text: string, width: number): string {
+  return truncateStatusText(text, width) ?? "";
+}
+
+export function todoStatusSummary(tasks: readonly TodoTask[]): string {
+  if (tasks.length === 0) return "no tasks";
+  const parts: string[] = [];
+  for (const status of TODO_STATUSES) {
+    const count = tasks.filter((task) => task.status === status).length;
+    if (count > 0) parts.push(`${count} ${status}`);
+  }
+  return parts.join(" · ");
+}
+
+export function todoEmptyLines(
+  agentName: string,
+  filter: TodoFilter,
+  hasAnyTask: boolean,
+): string[] {
+  if (hasAnyTask) return [`No ${filter} tasks.`, "Press f to change the filter."];
+  return [
+    `${agentName} has no tasks yet.`,
+    `${agentName} can call enable_tools with Todo, then todo_add.`,
+    "This view is read-only.",
+  ];
+}
+
+export function todoFooterText(
+  layout: TodoPopupLayout,
+  filter: TodoFilter,
+  position: number,
+  total: number,
+): string {
+  const counter = `${position}/${total}`;
+  const wide = `filter ${filter}   ${counter}   ↑↓ move   f filter   esc close`;
+  const narrow = `${filter}  ${counter}  ↑↓ f esc`;
+  // Truncating the wide form would cut the only hint for closing the popup,
+  // so it is used only where it fits whole.
+  const fits = !layout.narrow && statusTextWidth(wide) <= layout.contentWidth;
+  return fit(fits ? wide : narrow, layout.contentWidth);
+}
+
+export function TodoPopup({
+  theme,
+  terminalWidth,
+  terminalHeight,
+  agentName,
+  tasks,
+  filter,
+  selectedId,
+  now = Date.now(),
+}: {
+  theme: Theme;
+  terminalWidth: number;
+  terminalHeight: number;
+  agentName: string;
+  tasks: readonly TodoTask[];
+  filter: TodoFilter;
+  selectedId: string | null;
+  now?: number;
+}) {
+  const layout = todoPopupLayout(terminalWidth, terminalHeight);
+  const visible = visibleTodoTasks(tasks, filter);
+  const selectedIndex = visible.findIndex((task) => task.id === selectedId);
+  // Centring the selection keeps the rows after it on screen; anchoring it to
+  // the last visible row would hide everything below.
+  const maxWindowStart = Math.max(0, visible.length - layout.listHeight);
+  const windowStart = selectedIndex < 0
+    ? 0
+    : Math.min(
+      maxWindowStart,
+      Math.max(0, selectedIndex - Math.floor((layout.listHeight - 1) / 2)),
+    );
+  const rows = visible.slice(windowStart, windowStart + layout.listHeight);
+  const emptyLines = todoEmptyLines(agentName, filter, tasks.length > 0)
+    .map((line) => fit(line, layout.contentWidth))
+    .slice(0, layout.listHeight);
+
+  return (
+    <PopupFrame
+      theme={theme}
+      terminalWidth={terminalWidth}
+      terminalHeight={terminalHeight}
+      geometry={{
+        top: layout.top,
+        left: layout.margin,
+        width: layout.popupWidth,
+        height: layout.popupHeight,
+      }}
+      zIndex={100}
+      title={` ${fit(`Todo · ${agentName}`, Math.max(1, layout.popupWidth - 4))} `}
+    >
+      {layout.listHeight ? <box
+        style={{
+          height: layout.listHeight,
+          width: layout.contentWidth,
+          flexShrink: 0,
+          flexDirection: "column",
+          overflow: "hidden",
+        }}
+      >
+        {visible.length === 0
+          ? emptyLines.map((line, at) => (
+            <text
+              key={`empty-${at}`}
+              content={line}
+              fg={theme.dim}
+              bg={theme.popupBg}
+              wrapMode="none"
+              style={{ height: 1, flexShrink: 0 }}
+            />
+          ))
+          : rows.map((task) => {
+            const selected = task.id === selectedId;
+            const rowBg = selected ? theme.selectionBg : theme.popupBg;
+            return (
+              <box
+                key={task.id}
+                id={`todo-${task.id}`}
+                style={{
+                  height: 1,
+                  width: layout.contentWidth,
+                  flexShrink: 0,
+                  flexDirection: "row",
+                  backgroundColor: rowBg,
+                  overflow: "hidden",
+                }}
+              >
+                {layout.markerWidth ? <text
+                  content={selected ? "› " : "  "}
+                  fg={theme.accent}
+                  bg={rowBg}
+                  wrapMode="none"
+                  style={{ width: layout.markerWidth, flexShrink: 0 }}
+                /> : null}
+                {layout.glyphWidth ? <text
+                  content={`${STATUS_GLYPHS[task.status]} `}
+                  fg={statusColor(theme, task.status)}
+                  bg={rowBg}
+                  wrapMode="none"
+                  style={{ width: layout.glyphWidth, flexShrink: 0 }}
+                /> : null}
+                <text
+                  content={fit(task.text, layout.textWidth)}
+                  fg={selected ? theme.accent : theme.fg}
+                  bg={rowBg}
+                  wrapMode="none"
+                  style={{ width: layout.textWidth, flexShrink: 0 }}
+                />
+                {layout.idWidth ? <text
+                  content={` ${fit(task.id, TODO_ID_LENGTH)}`}
+                  fg={theme.dim}
+                  bg={rowBg}
+                  wrapMode="none"
+                  style={{ width: layout.idWidth, flexShrink: 0 }}
+                /> : null}
+                {layout.ageWidth ? <text
+                  content={` ${fit(formatAge(task.updatedAt, now), layout.ageWidth - 1)}`}
+                  fg={theme.dim}
+                  bg={rowBg}
+                  wrapMode="none"
+                  style={{ width: layout.ageWidth, flexShrink: 0 }}
+                /> : null}
+              </box>
+            );
+          })}
+      </box> : null}
+      {layout.separatorHeight ? <box style={{ height: layout.separatorHeight, flexShrink: 0 }}>
+        <text
+          content={"─".repeat(layout.contentWidth)}
+          fg={theme.border}
+          bg={theme.popupBg}
+          wrapMode="none"
+        />
+      </box> : null}
+      {layout.summaryHeight ? <text
+        content={fit(todoStatusSummary(tasks), layout.contentWidth)}
+        fg={theme.dim}
+        bg={theme.popupBg}
+        wrapMode="none"
+        style={{ height: layout.summaryHeight, flexShrink: 0 }}
+      /> : null}
+      {layout.footerHeight ? <text
+        content={todoFooterText(
+          layout,
+          filter,
+          selectedIndex < 0 ? 0 : selectedIndex + 1,
+          visible.length,
+        )}
+        fg={theme.dim}
+        bg={theme.popupBg}
+        wrapMode="none"
+        style={{ height: layout.footerHeight, flexShrink: 0 }}
+      /> : null}
+    </PopupFrame>
+  );
+}

--- a/src/todo.test.ts
+++ b/src/todo.test.ts
@@ -1,0 +1,364 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import {
+  MAX_TODOS,
+  MAX_TODO_TEXT,
+  TODO_STATUSES,
+  addTodoTask,
+  createTodoTask,
+  deleteTodoTask,
+  isTodoStatus,
+  loadTodoTasks,
+  normalizeTodoText,
+  saveTodoTasks,
+  sortTodoTasks,
+  todoFileFor,
+  updateTodoTask,
+  updateTodoTasks,
+  type TodoTask,
+} from "./todo";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function tempSessionFile(): string {
+  const directory = mkdtempSync(join(tmpdir(), "pum-todo-"));
+  temporaryDirectories.push(directory);
+  return join(directory, "session-id.jsonl");
+}
+
+function task(partial: Partial<TodoTask> = {}): TodoTask {
+  return {
+    id: "task-1",
+    text: "write the parser",
+    status: "pending",
+    createdAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_000_000,
+    ...partial,
+  };
+}
+
+describe("task creation", () => {
+  test("trims the text and defaults to pending", () => {
+    expect(createTodoTask("  write the parser  ", undefined, 42, "task-1")).toEqual({
+      id: "task-1",
+      text: "write the parser",
+      status: "pending",
+      createdAt: 42,
+      updatedAt: 42,
+    });
+  });
+
+  test("keeps a supplied valid status", () => {
+    expect(createTodoTask("ship it", "active", 42, "task-1").status).toBe("active");
+  });
+
+  test("rejects empty, blank and overlong text", () => {
+    expect(() => createTodoTask("")).toThrow("a task needs text");
+    expect(() => createTodoTask("   ")).toThrow("a task needs text");
+    expect(() => createTodoTask("\n\t")).toThrow("a task needs text");
+    expect(() => createTodoTask("x".repeat(MAX_TODO_TEXT + 1))).toThrow(String(MAX_TODO_TEXT));
+  });
+
+  test("rejects NUL and escape, and folds a newline into one space", () => {
+    expect(() => createTodoTask("bad\0text")).toThrow("control characters");
+    expect(() => createTodoTask("clear\u001b[2Jthe screen")).toThrow("control characters");
+    expect(normalizeTodoText("write  the\n\tparser")).toBe("write the parser");
+  });
+
+  test("accepts text at exactly the limit", () => {
+    expect(normalizeTodoText("x".repeat(MAX_TODO_TEXT))).toHaveLength(MAX_TODO_TEXT);
+  });
+
+  test("rejects an unknown status", () => {
+    expect(() => createTodoTask("ship it", "done")).toThrow("unknown task status");
+    expect(isTodoStatus("done")).toBe(false);
+    expect(TODO_STATUSES.every(isTodoStatus)).toBe(true);
+  });
+});
+
+describe("canonical order", () => {
+  test("orders by status, then oldest first, then id", () => {
+    const tasks: TodoTask[] = [
+      task({ id: "e", status: "cancelled", createdAt: 1 }),
+      task({ id: "d", status: "completed", createdAt: 1 }),
+      task({ id: "c", status: "blocked", createdAt: 1 }),
+      task({ id: "b", status: "pending", createdAt: 1 }),
+      task({ id: "a", status: "active", createdAt: 1 }),
+    ];
+    expect(sortTodoTasks(tasks).map((entry) => entry.id)).toEqual(["a", "b", "c", "d", "e"]);
+  });
+
+  test("breaks a status tie by createdAt then by id", () => {
+    const tasks: TodoTask[] = [
+      task({ id: "z", createdAt: 5 }),
+      task({ id: "a", createdAt: 9 }),
+      task({ id: "b", createdAt: 5 }),
+    ];
+    expect(sortTodoTasks(tasks).map((entry) => entry.id)).toEqual(["b", "z", "a"]);
+  });
+
+  test("leaves the input untouched", () => {
+    const tasks: TodoTask[] = [task({ id: "b", status: "completed" }), task({ id: "a" })];
+    sortTodoTasks(tasks);
+    expect(tasks.map((entry) => entry.id)).toEqual(["b", "a"]);
+  });
+});
+
+describe("mutation", () => {
+  test("appends and rejects a duplicate id", () => {
+    const one = addTodoTask([], "first", undefined, 1, "task-1");
+    expect(one).toHaveLength(1);
+    expect(() => addTodoTask(one, "again", undefined, 2, "task-1")).toThrow("duplicate task id");
+  });
+
+  test("updates text and status and bumps updatedAt", () => {
+    const tasks = [task()];
+    const next = updateTodoTask(tasks, "task-1", { status: "active" }, 99);
+    expect(next[0]).toMatchObject({ status: "active", updatedAt: 99 });
+    expect(tasks[0]?.status).toBe("pending");
+  });
+
+  test("leaves updatedAt alone when nothing changes", () => {
+    const next = updateTodoTask([task()], "task-1", { text: "write the parser" }, 99);
+    expect(next[0]?.updatedAt).toBe(1_700_000_000_000);
+  });
+
+  test("rejects an unknown id, unknown status and bad text", () => {
+    expect(() => updateTodoTask([task()], "nope", { status: "active" })).toThrow("unknown task id");
+    expect(() => updateTodoTask([task()], "task-1", { status: "done" })).toThrow("unknown task status");
+    expect(() => updateTodoTask([task()], "task-1", { text: "" })).toThrow("a task needs text");
+    expect(() => deleteTodoTask([task()], "nope")).toThrow("unknown task id");
+  });
+
+  test("deletes only the named task", () => {
+    const tasks = [task({ id: "a" }), task({ id: "b", status: "completed" })];
+    expect(deleteTodoTask(tasks, "a").map((entry) => entry.id)).toEqual(["b"]);
+  });
+});
+
+describe("the task cap", () => {
+  function fill(count: number): TodoTask[] {
+    return Array.from({ length: count }, (_unused, index) =>
+      task({ id: `task-${index}`, createdAt: index }));
+  }
+
+  test("accepts the hundredth task and rejects the hundred and first", () => {
+    const full = addTodoTask(fill(MAX_TODOS - 1), "last", undefined, 1, "task-last");
+    expect(full).toHaveLength(MAX_TODOS);
+    expect(() => addTodoTask(full, "one too many", undefined, 2, "task-extra"))
+      .toThrow(`at most ${MAX_TODOS}`);
+  });
+
+  test("counts completed and cancelled tasks too", () => {
+    const finished = fill(MAX_TODOS).map((entry, index) => ({
+      ...entry,
+      status: index % 2 === 0 ? ("completed" as const) : ("cancelled" as const),
+    }));
+    expect(() => addTodoTask(finished, "one more", undefined, 1, "task-extra"))
+      .toThrow(`at most ${MAX_TODOS}`);
+  });
+});
+
+describe("the companion file path", () => {
+  test("sits beside the session with the host separator", () => {
+    const sessionFile = join("some", "dir", "session-id.jsonl");
+    const file = todoFileFor(sessionFile);
+    expect(basename(file)).toBe("session-id.todo.json");
+    expect(dirname(file)).toBe(join("some", "dir"));
+  });
+
+  test("strips a .json session suffix as well", () => {
+    expect(basename(todoFileFor(join("d", "abc.json")))).toBe("abc.todo.json");
+  });
+});
+
+describe("persistence", () => {
+  test("round-trips a saved list", () => {
+    const sessionFile = tempSessionFile();
+    const tasks = [task({ id: "a" }), task({ id: "b", status: "completed" })];
+    saveTodoTasks(sessionFile, tasks);
+    expect(loadTodoTasks(sessionFile)).toEqual(tasks);
+  });
+
+  test("leaves no temp file behind and renames into place", () => {
+    const sessionFile = tempSessionFile();
+    saveTodoTasks(sessionFile, [task()]);
+    const written = readdirSync(dirname(sessionFile));
+    expect(written).toEqual(["session-id.todo.json"]);
+  });
+
+  test("writes nothing for an empty list with no file", () => {
+    const sessionFile = tempSessionFile();
+    saveTodoTasks(sessionFile, []);
+    expect(existsSync(todoFileFor(sessionFile))).toBe(false);
+    expect(loadTodoTasks(sessionFile)).toEqual([]);
+  });
+
+  test("clears an existing file down to an empty list", () => {
+    const sessionFile = tempSessionFile();
+    saveTodoTasks(sessionFile, [task()]);
+    saveTodoTasks(sessionFile, []);
+    expect(loadTodoTasks(sessionFile)).toEqual([]);
+    expect(existsSync(todoFileFor(sessionFile))).toBe(true);
+  });
+
+  test("holds a sessionless list in memory instead of a file", () => {
+    expect(loadTodoTasks(undefined)).toEqual([]);
+    saveTodoTasks(undefined, [task()]);
+    expect(loadTodoTasks(undefined)).toEqual([task()]);
+    saveTodoTasks(undefined, []);
+    expect(loadTodoTasks(undefined)).toEqual([]);
+  });
+
+  test("returns an empty list for corrupt, non-array and missing files", () => {
+    const sessionFile = tempSessionFile();
+    expect(loadTodoTasks(sessionFile)).toEqual([]);
+    writeFileSync(todoFileFor(sessionFile), "{ not json", "utf8");
+    expect(loadTodoTasks(sessionFile)).toEqual([]);
+    writeFileSync(todoFileFor(sessionFile), JSON.stringify({ tasks: [] }), "utf8");
+    expect(loadTodoTasks(sessionFile)).toEqual([]);
+  });
+
+  test("drops invalid entries instead of failing the whole load", () => {
+    const sessionFile = tempSessionFile();
+    writeFileSync(todoFileFor(sessionFile), JSON.stringify([
+      task({ id: "good" }),
+      null,
+      "task",
+      { ...task({ id: "no-status" }), status: "done" },
+      { ...task({ id: "blank" }), text: "   " },
+      { ...task({ id: "nul" }), text: "bad\0text" },
+      { ...task({ id: "long" }), text: "x".repeat(MAX_TODO_TEXT + 1) },
+      { ...task({ id: "" }) },
+      { ...task({ id: "no-time" }), createdAt: "yesterday" },
+      task({ id: "also-good", status: "active" }),
+    ]), "utf8");
+    expect(loadTodoTasks(sessionFile).map((entry) => entry.id)).toEqual(["good", "also-good"]);
+  });
+
+  test("keeps the first of two entries sharing an id", () => {
+    const sessionFile = tempSessionFile();
+    writeFileSync(todoFileFor(sessionFile), JSON.stringify([
+      task({ id: "dupe", text: "first" }),
+      task({ id: "dupe", text: "second" }),
+    ]), "utf8");
+    const loaded = loadTodoTasks(sessionFile);
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0]?.text).toBe("first");
+  });
+
+  test("caps an oversized file by dropping the lowest-priority tasks", () => {
+    const sessionFile = tempSessionFile();
+    writeFileSync(todoFileFor(sessionFile), JSON.stringify([
+      ...Array.from({ length: MAX_TODOS + 19 }, (_unused, index) =>
+        task({ id: `done-${index}`, status: "completed", createdAt: index })),
+      task({ id: "still-running", status: "active", createdAt: 5_000 }),
+    ]), "utf8");
+    const loaded = loadTodoTasks(sessionFile);
+    expect(loaded).toHaveLength(MAX_TODOS);
+    // The active task sits last in the file and must survive the cap.
+    expect(loaded.map((entry) => entry.id)).toContain("still-running");
+  });
+
+  test("keeps file order when the file fits", () => {
+    const sessionFile = tempSessionFile();
+    const tasks = [task({ id: "b", status: "completed" }), task({ id: "a", status: "active" })];
+    saveTodoTasks(sessionFile, tasks);
+    expect(loadTodoTasks(sessionFile).map((entry) => entry.id)).toEqual(["b", "a"]);
+  });
+});
+
+describe("serialized updates", () => {
+  test("keeps every task when writers run in parallel", async () => {
+    const sessionFile = tempSessionFile();
+    const results = await Promise.all(
+      Array.from({ length: 10 }, (_unused, index) =>
+        updateTodoTasks(sessionFile, (tasks) =>
+          addTodoTask(tasks, `task ${index}`, undefined, index, `task-${index}`))),
+    );
+    expect(results.at(-1)).toHaveLength(10);
+    expect(loadTodoTasks(sessionFile)).toHaveLength(10);
+  });
+
+  test("holds the cap against parallel writers", async () => {
+    const sessionFile = tempSessionFile();
+    saveTodoTasks(sessionFile, Array.from({ length: MAX_TODOS - 1 }, (_unused, index) =>
+      task({ id: `seed-${index}`, createdAt: index })));
+    const settled = await Promise.allSettled(
+      Array.from({ length: 3 }, (_unused, index) =>
+        updateTodoTasks(sessionFile, (tasks) =>
+          addTodoTask(tasks, `late ${index}`, undefined, index, `late-${index}`))),
+    );
+    expect(settled.filter((entry) => entry.status === "fulfilled")).toHaveLength(1);
+    expect(loadTodoTasks(sessionFile)).toHaveLength(MAX_TODOS);
+  });
+
+  test("a rejected mutation leaves the file untouched", async () => {
+    const sessionFile = tempSessionFile();
+    await updateTodoTasks(sessionFile, (tasks) =>
+      addTodoTask(tasks, "keep me", undefined, 1, "task-1"));
+    const before = readFileSync(todoFileFor(sessionFile), "utf8");
+    await expect(updateTodoTasks(sessionFile, (tasks) =>
+      updateTodoTask(tasks, "gone", { status: "completed" }))).rejects.toThrow("unknown task id");
+    expect(readFileSync(todoFileFor(sessionFile), "utf8")).toBe(before);
+  });
+
+  test("a rejection does not poison later writers", async () => {
+    const sessionFile = tempSessionFile();
+    const failed = updateTodoTasks(sessionFile, () => {
+      throw new Error("boom");
+    });
+    const added = updateTodoTasks(sessionFile, (tasks) =>
+      addTodoTask(tasks, "after the failure", undefined, 1, "task-1"));
+    await expect(failed).rejects.toThrow("boom");
+    expect(await added).toHaveLength(1);
+  });
+
+  test("refuses to store a duplicate id a mutation invents", async () => {
+    const sessionFile = tempSessionFile();
+    await expect(updateTodoTasks(sessionFile, () => [task({ id: "same" }), task({ id: "same" })]))
+      .rejects.toThrow("duplicate task id");
+    expect(existsSync(todoFileFor(sessionFile))).toBe(false);
+  });
+
+  test("keeps a sessionless list in memory", async () => {
+    try {
+      expect(await updateTodoTasks(undefined, (tasks) =>
+        addTodoTask(tasks, "nowhere", undefined, 1, "task-1"))).toHaveLength(1);
+      expect(loadTodoTasks(undefined).map((entry) => entry.text)).toEqual(["nowhere"]);
+      expect(await updateTodoTasks(undefined, (tasks) =>
+        deleteTodoTask(tasks, "task-1"))).toEqual([]);
+      await expect(updateTodoTasks(undefined, (tasks) =>
+        deleteTodoTask(tasks, "task-1"))).rejects.toThrow("unknown task id");
+    } finally {
+      saveTodoTasks(undefined, []);
+    }
+  });
+
+  test("reports a failed write instead of claiming success", async () => {
+    const sessionFile = tempSessionFile();
+    // A directory where the companion file belongs fails the rename on every
+    // platform, which is the cheapest stand-in for a full or read-only disk.
+    mkdirSync(todoFileFor(sessionFile));
+    await expect(updateTodoTasks(sessionFile, (tasks) =>
+      addTodoTask(tasks, "unwritable", undefined, 1, "task-1"))).rejects.toThrow();
+    // The temp file goes with it; a failed write leaves nothing behind.
+    expect(readdirSync(dirname(sessionFile))).toEqual(["session-id.todo.json"]);
+  });
+});

--- a/src/todo.ts
+++ b/src/todo.ts
@@ -1,0 +1,292 @@
+import { basename, dirname, join } from "node:path";
+import { existsSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+
+/**
+ * Per-agent todo lists.
+ *
+ * A pure state layer: validation, canonical ordering, and a companion file
+ * beside the session JSONL. Tools and the popup build on this and own no
+ * state of their own, so every writer shares one cap and one order.
+ */
+
+export type TodoStatus = "pending" | "active" | "blocked" | "completed" | "cancelled";
+
+/**
+ * Canonical status order. Sorting and the status guard both read this array,
+ * so a new status can only ever be added in one place.
+ */
+export const TODO_STATUSES: readonly TodoStatus[] = [
+  "active",
+  "pending",
+  "blocked",
+  "completed",
+  "cancelled",
+];
+
+/** Longest task text PUM stores. Longer input is refused, never truncated. */
+export const MAX_TODO_TEXT = 500;
+
+/** The list never holds more than this many tasks, whatever their status. */
+export const MAX_TODOS = 100;
+
+export type TodoTask = {
+  /** Stable opaque identifier. */
+  id: string;
+  /** Non-empty task text, at most MAX_TODO_TEXT characters. */
+  text: string;
+  status: TodoStatus;
+  /** Epoch milliseconds. */
+  createdAt: number;
+  /** Epoch milliseconds of the last accepted change. */
+  updatedAt: number;
+};
+
+export function isTodoStatus(value: unknown): value is TodoStatus {
+  return TODO_STATUSES.includes(value as TodoStatus);
+}
+
+/** Companion file next to the session JSONL: <session>.todo.json */
+export function todoFileFor(sessionFile: string): string {
+  const base = basename(sessionFile).replace(/\.jsonl?$/, "");
+  return join(dirname(sessionFile), `${base}.todo.json`);
+}
+
+/**
+ * NUL truncates the text in C string APIs, and ESC lets task text repaint the
+ * terminal the popup draws it into. Tab, newline and return collapse to a
+ * space before this runs, so only the harmful controls reach it.
+ */
+const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f-\u009f]/;
+
+/** Flatten and check task text. Throws with the reason the caller should show. */
+export function normalizeTodoText(value: unknown): string {
+  if (typeof value !== "string") throw new Error("a task needs text");
+  // A task is one line in the popup, so runs of whitespace become one space.
+  const text = value.replace(/\s+/g, " ").trim();
+  if (!text) throw new Error("a task needs text");
+  if (CONTROL_CHARACTERS.test(text)) {
+    throw new Error("task text cannot hold control characters");
+  }
+  if (text.length > MAX_TODO_TEXT) {
+    throw new Error(`a task is at most ${MAX_TODO_TEXT} characters`);
+  }
+  return text;
+}
+
+function normalizeStatus(value: unknown): TodoStatus {
+  if (value === undefined) return "pending";
+  if (!isTodoStatus(value)) throw new Error(`unknown task status: ${String(value)}`);
+  return value;
+}
+
+export function createTodoTask(
+  text: string,
+  status?: unknown,
+  now = Date.now(),
+  id = randomUUID().slice(0, 12),
+): TodoTask {
+  return {
+    id,
+    text: normalizeTodoText(text),
+    status: normalizeStatus(status),
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+/**
+ * Canonical order: status, then oldest first, then id so two tasks written in
+ * the same millisecond never swap places between renders.
+ */
+export function sortTodoTasks(tasks: readonly TodoTask[]): TodoTask[] {
+  return [...tasks].sort((left, right) => {
+    const byStatus = TODO_STATUSES.indexOf(left.status) - TODO_STATUSES.indexOf(right.status);
+    if (byStatus !== 0) return byStatus;
+    if (left.createdAt !== right.createdAt) return left.createdAt - right.createdAt;
+    return left.id < right.id ? -1 : left.id > right.id ? 1 : 0;
+  });
+}
+
+/** Append a task. Throws when the text is bad or the list is full. */
+export function addTodoTask(
+  tasks: readonly TodoTask[],
+  text: string,
+  status?: unknown,
+  now = Date.now(),
+  id = randomUUID().slice(0, 12),
+): TodoTask[] {
+  const task = createTodoTask(text, status, now, id);
+  if (tasks.length >= MAX_TODOS) throw new Error(`the list holds at most ${MAX_TODOS} tasks`);
+  if (tasks.some((existing) => existing.id === task.id)) {
+    throw new Error(`duplicate task id: ${task.id}`);
+  }
+  return [...tasks, task];
+}
+
+/** Change text, status, or both. Throws on an unknown id or bad input. */
+export function updateTodoTask(
+  tasks: readonly TodoTask[],
+  id: string,
+  changes: { text?: string; status?: unknown },
+  now = Date.now(),
+): TodoTask[] {
+  const index = tasks.findIndex((task) => task.id === id);
+  if (index < 0) throw new Error(`unknown task id: ${id}`);
+  const current = tasks[index] as TodoTask;
+  const text = changes.text === undefined ? current.text : normalizeTodoText(changes.text);
+  const status = changes.status === undefined ? current.status : normalizeStatus(changes.status);
+  // A no-op must not bump updatedAt, or reordering by time would drift.
+  if (text === current.text && status === current.status) return [...tasks];
+  const next = [...tasks];
+  next[index] = { ...current, text, status, updatedAt: now };
+  return next;
+}
+
+/** Drop a task. Completed and cancelled ones only leave this way. */
+export function deleteTodoTask(tasks: readonly TodoTask[], id: string): TodoTask[] {
+  const index = tasks.findIndex((task) => task.id === id);
+  if (index < 0) throw new Error(`unknown task id: ${id}`);
+  return tasks.filter((_, at) => at !== index);
+}
+
+function isTodoTask(value: unknown): value is TodoTask {
+  if (!value || typeof value !== "object") return false;
+  const task = value as Record<string, unknown>;
+  return (
+    typeof task.id === "string" && task.id.length > 0 && !CONTROL_CHARACTERS.test(task.id) &&
+    typeof task.text === "string" &&
+    task.text.trim().length > 0 &&
+    task.text.length <= MAX_TODO_TEXT &&
+    !CONTROL_CHARACTERS.test(task.text) &&
+    isTodoStatus(task.status) &&
+    typeof task.createdAt === "number" && Number.isFinite(task.createdAt) &&
+    typeof task.updatedAt === "number" && Number.isFinite(task.updatedAt)
+  );
+}
+
+/**
+ * A run with no session file still needs a working list, so it keeps one in
+ * memory. It dies with the process; there is nothing to persist.
+ */
+let sessionlessTasks: readonly TodoTask[] = [];
+
+/**
+ * Load the persisted list for a session. Never throws: a missing, unreadable
+ * or corrupt file reads as an empty list, and single bad entries are dropped.
+ */
+export function loadTodoTasks(sessionFile: string | undefined): TodoTask[] {
+  if (!sessionFile) return [...sessionlessTasks];
+  try {
+    const file = todoFileFor(sessionFile);
+    if (!existsSync(file)) return [];
+    const parsed: unknown = JSON.parse(readFileSync(file, "utf8"));
+    if (!Array.isArray(parsed)) return [];
+    const seen = new Set<string>();
+    const tasks: TodoTask[] = [];
+    for (const entry of parsed) {
+      if (!isTodoTask(entry)) continue;
+      // A file edited by hand can repeat an id; the first one wins so every
+      // later lookup by id stays unambiguous.
+      if (seen.has(entry.id)) continue;
+      seen.add(entry.id);
+      tasks.push({
+        id: entry.id,
+        text: entry.text,
+        status: entry.status,
+        createdAt: entry.createdAt,
+        updatedAt: entry.updatedAt,
+      });
+    }
+    // File order is arbitrary, so an oversized file drops its lowest-priority
+    // tasks rather than whatever happens to sit past the hundredth line.
+    return tasks.length > MAX_TODOS ? sortTodoTasks(tasks).slice(0, MAX_TODOS) : tasks;
+  } catch {
+    return [];
+  }
+}
+
+/** Write the list atomically. Throws so a caller in a transaction can react. */
+function writeTodoTasks(sessionFile: string | undefined, tasks: readonly TodoTask[]): void {
+  if (!sessionFile) {
+    sessionlessTasks = [...tasks];
+    return;
+  }
+  const file = todoFileFor(sessionFile);
+  // An empty list with no companion file is nothing to record. Writing it
+  // would leave a two-byte "[]" beside every session ever opened.
+  if (tasks.length === 0 && !existsSync(file)) return;
+  // The temp name carries pid and time so two PUM processes on one session
+  // cannot clobber each other's half-written file before the rename.
+  const temporary = `${file}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    writeFileSync(temporary, JSON.stringify(tasks.slice(0, MAX_TODOS), null, 2), "utf8");
+    renameSync(temporary, file);
+  } catch (error) {
+    // The name is never reused, so a leftover temp file would sit there forever.
+    try {
+      rmSync(temporary, { force: true });
+    } catch {
+      // Nothing more to try; the write already failed.
+    }
+    throw error;
+  }
+}
+
+/** Persist the list atomically next to the session. Best effort only. */
+export function saveTodoTasks(
+  sessionFile: string | undefined,
+  tasks: readonly TodoTask[],
+): void {
+  try {
+    writeTodoTasks(sessionFile, tasks);
+  } catch {
+    // A failed todo write never breaks the session.
+  }
+}
+
+function assertStorable(tasks: readonly TodoTask[]): void {
+  if (tasks.length > MAX_TODOS) throw new Error(`the list holds at most ${MAX_TODOS} tasks`);
+  const seen = new Set<string>();
+  for (const task of tasks) {
+    if (!isTodoTask(task)) throw new Error("the list holds an invalid task");
+    if (seen.has(task.id)) throw new Error(`duplicate task id: ${task.id}`);
+    seen.add(task.id);
+  }
+}
+
+/** One promise chain per companion file, so writers queue instead of racing. */
+const chains = new Map<string, Promise<unknown>>();
+
+/**
+ * Serialized read-modify-write. Every mutation reads the file again inside the
+ * chain, so two parallel tool calls cannot each save a stale list and lose the
+ * other's task or push the total past the cap. A mutation that throws leaves
+ * the file exactly as it was, and so does a failed write.
+ *
+ * The chain covers this process only. Two PUM processes on one session file
+ * still race, exactly as they already do for the goal and news companions.
+ */
+export function updateTodoTasks(
+  sessionFile: string | undefined,
+  mutate: (tasks: TodoTask[]) => readonly TodoTask[],
+): Promise<TodoTask[]> {
+  // Sessionless runs share one key, which is also their one in-memory list.
+  const key = sessionFile ? todoFileFor(sessionFile) : "";
+  const previous = chains.get(key) ?? Promise.resolve();
+  const result = previous.then(() => {
+    const tasks = mutate(loadTodoTasks(sessionFile));
+    assertStorable(tasks);
+    const stored = [...tasks];
+    // Not saveTodoTasks: a caller that just added a task must hear about a
+    // failed write, or it reports success over a list that never landed.
+    writeTodoTasks(sessionFile, stored);
+    return stored;
+  });
+  // A rejection must not poison the chain, and the key goes once it drains.
+  const drained: Promise<void> = result.then(() => {}, () => {}).then(() => {
+    if (chains.get(key) === drained) chains.delete(key);
+  });
+  chains.set(key, drained);
+  return result;
+}


### PR DESCRIPTION
Builds on PR #21 (`feat/todo-model`) — this branch merges it, so review the `src/todo-popup.*` files only. Merge #21 first.

Part of #12.

## What this adds

`src/todo-popup.tsx`: a presentational popup that renders one agent's todo list. It owns no keyboard handler — all key routing stays in the single `useKeyboard` in `app.tsx`, which the coordinator wires up. The popup exports the pure helpers that handler drives it with:

- `todoPopupLayout(width, height)` — geometry plus per-section heights and per-column widths. Sections drop in order (separator, then the status summary) as the terminal shrinks; the footer and one task row always survive, and the last terminal row stays free for `PopupFrame`'s shadow.
- `visibleTodoTasks(tasks, filter)` — filter plus `sortTodoTasks` from `src/todo.ts`, so the tools and the popup order tasks identically.
- `moveTodoSelection(tasks, selectedId, step)` — wrapping, `null` on an empty list.
- `cycleTodoFilter(current)` — `all` then the canonical status order, derived from `TODO_STATUSES` so a new status joins the cycle by itself.

Each row shows a status glyph (colour alone never carries the status), the task text, a short id so two similar tasks stay apart, and the updated age via the existing `formatAge`. Text and footer cut through `truncateStatusText`, so nothing splits a grapheme or spills past the popup. Colours are semantic theme tokens only.

The empty state names the tools the **selected agent** can call — `enable_tools` with `Todo`, then `todo_add` — and says the view is read-only.

## Tests

`src/todo-popup.test.tsx`, 24 tests: canonical ordering, every filter, selection movement and its boundaries, the empty state naming `enable_tools` and `Todo`, column and footer widths swept across 30–200 columns, short terminals keeping the footer, and long text truncating on a grapheme boundary.

`bun test`: 1151 pass, 2 fail — `prompt-input-layout.test.tsx` (flaky under load) and `subagents/ui.test.tsx` (asserts a status string that only fits a short checkout path). Both fail on `main` in every agent worktree. `bunx tsc --noEmit` clean.