### PR TITLE
Harden the todo model against what it accepts

### DIFF
--- a/src/todo-tools.test.ts
+++ b/src/todo-tools.test.ts
@@ -329,20 +329,28 @@ describe("todo tools", () => {
     expect((await main.call("todo_list")).details.count).toBe(1);
   });
 
-  test("todo_list survives an absurd timestamp in the file", async () => {
+  test("todo_list drops a task whose timestamp no consumer could format", async () => {
     const { call, todoFile } = fixture();
     const created = (await call("todo_add", { text: "hand edited" })).details.task as TodoTask;
     writeFileSync(
       todoFile,
-      JSON.stringify([{ ...created, createdAt: 1e20, updatedAt: 1e20 }]),
+      JSON.stringify([
+        { ...created, createdAt: 1e20, updatedAt: 1e20 },
+        { ...created, id: "kept00", text: "intact" },
+      ]),
       "utf8",
     );
 
+    // A time past the Date range is corrupt, not merely odd, so it is dropped
+    // like any other bad entry rather than kept to break whoever formats it.
     const listed = await call("todo_list");
     expect(listed.details.count).toBe(1);
-    expect(listed.content[0]!.text).toContain(String(1e20));
-    // The task stays reachable, so the agent can still delete it.
-    expect((await call("todo_delete", { id: created.id })).details.task.id).toBe(created.id);
+    expect(listed.content[0]!.text).toContain("intact");
+    expect(listed.content[0]!.text).not.toContain(String(1e20));
+
+    // The surviving task still writes cleanly, which drops the bad one for good.
+    await call("todo_add", { text: "after" });
+    expect((await call("todo_list")).details.count).toBe(2);
   });
 
   test("load rebinds the controller to a session started later", async () => {

--- a/src/todo.ts
+++ b/src/todo.ts
@@ -56,8 +56,25 @@ export function todoFileFor(sessionFile: string): string {
  * NUL truncates the text in C string APIs, and ESC lets task text repaint the
  * terminal the popup draws it into. Tab, newline and return collapse to a
  * space before this runs, so only the harmful controls reach it.
+ *
+ * Bidi overrides and isolates are here for the same reason: they cost no width
+ * and reorder what follows, so a task can render as text it does not contain.
+ * The joiners U+200C and U+200D are not blocked - they carry meaning in emoji
+ * and in Indic and Arabic scripts, and dropping them corrupts real text.
  */
-const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f-\u009f]/;
+const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f-\u009f\u200b\u2028\u2029\u202a-\u202e\u2066-\u2069\ufeff]/;
+
+/**
+ * Largest value `Date` accepts. A finite number past it survives JSON and the
+ * old guard, then throws in every consumer that formats it - including the one
+ * listing the tasks, which is where the id needed to delete it comes from.
+ */
+const MAX_TIME = 8.64e15;
+
+function isStorableTime(value: unknown): boolean {
+  return typeof value === "number" && Number.isFinite(value)
+    && value >= 0 && value <= MAX_TIME;
+}
 
 /** Flatten and check task text. Throws with the reason the caller should show. */
 export function normalizeTodoText(value: unknown): string {
@@ -160,8 +177,8 @@ function isTodoTask(value: unknown): value is TodoTask {
     task.text.length <= MAX_TODO_TEXT &&
     !CONTROL_CHARACTERS.test(task.text) &&
     isTodoStatus(task.status) &&
-    typeof task.createdAt === "number" && Number.isFinite(task.createdAt) &&
-    typeof task.updatedAt === "number" && Number.isFinite(task.updatedAt)
+    isStorableTime(task.createdAt) &&
+    isStorableTime(task.updatedAt)
   );
 }
 
@@ -220,7 +237,13 @@ function writeTodoTasks(sessionFile: string | undefined, tasks: readonly TodoTas
   // cannot clobber each other's half-written file before the rename.
   const temporary = `${file}.${process.pid}.${Date.now()}.tmp`;
   try {
-    writeFileSync(temporary, JSON.stringify(tasks.slice(0, MAX_TODOS), null, 2), "utf8");
+    // Storage keeps insertion order; the popup sorts for display. Only an
+    // overflowing list is sorted first, so the tasks that matter least drop
+    // instead of whatever happened to sit last.
+    const stored = tasks.length > MAX_TODOS
+      ? sortTodoTasks(tasks).slice(0, MAX_TODOS)
+      : tasks;
+    writeFileSync(temporary, JSON.stringify(stored, null, 2), "utf8");
     renameSync(temporary, file);
   } catch (error) {
     // The name is never reused, so a leftover temp file would sit there forever.
@@ -233,7 +256,12 @@ function writeTodoTasks(sessionFile: string | undefined, tasks: readonly TodoTas
   }
 }
 
-/** Persist the list atomically next to the session. Best effort only. */
+/**
+ * Persist the list atomically next to the session. Best effort only.
+ *
+ * This bypasses the serialization chain, so it can overwrite a task a tool
+ * added meanwhile. Seed state with it; mutate through `updateTodoTasks`.
+ */
 export function saveTodoTasks(
   sessionFile: string | undefined,
   tasks: readonly TodoTask[],


### PR DESCRIPTION
Follow-up to #21, from findings the tools unit (#24) surfaced while building against it. All three are reachable through a hand-edited or concurrently-written companion file.

- **A timestamp no consumer can format.** `isTodoTask` accepted any finite number, so `1e20` passed validation and then threw `RangeError` in `toISOString`. That broke `todo_list` — the one tool that reports the id needed to delete the offending entry. Now bounded to the `Date` range and dropped on load like any other corrupt entry, so it self-heals.
- **Overflow dropped the wrong tasks.** The write path sliced by array position while the load path sorts first, so an oversized file kept whatever happened to sit at the front. Now sorted before slicing — but only when the list actually overflows, so storage keeps insertion order in the normal case.
- **The display-safety guard was too narrow.** It covers C0/C1 but the comment claims it protects the popup, and bidi overrides and isolates got through. Those cost no width and reorder what follows.

One thing I deliberately did **not** block: the zero-width joiners U+200C and U+200D. They are load-bearing in emoji and in Indic and Arabic scripts — the first version of this patch blocked them and broke `👨‍👩‍👧‍👦`, which the popup's own grapheme test caught.

I also rewrote `todo_list survives an absurd timestamp in the file` from #24. It asserted the poison entry was kept so it stayed deletable; dropping it is better and matches that PR's own recommendation that the bound belongs in the validator.

`bun test`: 1277 pass, 1 skip, 0 fail. `tsc` clean.