### PR TITLE
Wire todo lists, /afk, and session-scoped settings into the app

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,8 @@ bun run start    # open the TUI in the current directory
 | Shift+Tab / Ctrl+Shift+Tab | Cycle agent transcripts forward/backward |
 | Ctrl+L | Open the agent transcript tree; use Up/Down and Right/Enter to select |
 | Esc | Once warns, twice within 2s cancels the selected agent's running turn |
-| Ctrl+P | Open settings; Esc closes, or steps back from the model list |
+| Ctrl+P | Open settings; `s` saves them as global; Esc closes, or steps back from the model list |
+| Ctrl+O | Open the selected agent's todo list; `f` filters, Esc closes |
 | Ctrl+T | Open process-local external triggers |
 | Ctrl+C | Clear the selected non-empty draft; on an empty draft, once arms and twice within 2s quits |
 | Questionnaire: ↑/↓, ←/→ or Tab, Enter, Esc | Select options, move questions, confirm, or cancel |
@@ -198,16 +199,20 @@ These were chosen deliberately. Change them only on purpose.
   blocks external
   location changes, writes, execution operands, ambiguous access, credential
   access, escaping links or junctions, broad deletion, and other hard rules.
-- **The main agent can deliberately edit exact PUM settings files.** The
-  authoritative main agent may `edit` or `bash`-write `settings.json`, `pum.json`,
-  and `theme.json` directly inside the PUM agent directory. The allowlist is
-  exact file names, never the whole config directory. Credentials stay denied:
-  `auth.json`, `models.json` key material, session content, and any other file
-  or subdirectory under the config directory keep the protected-path and
-  credential hard blocks. Managed subagents are blocked because they share the
-  host config directory. The native sandbox still denies the whole PUM config
-  root, so an enforced sandbox backend keeps config-root writes blocked even
-  when the deterministic layer approves them.
+- **No agent writes the PUM config directory.** Settings changed in the popup
+  belong to the session, not to `pum.json`, and `s` in the Settings popup is the
+  one deliberate promotion to global - performed by PUM itself, never through a
+  tool. The deterministic layer still supports an exact-file allowance, but
+  nothing grants one, so `settings.json`, `pum.json` and `theme.json` are
+  blocked for the main agent and for every subagent. `auth.json`, `models.json`
+  key material and session content keep their existing hard blocks, and the
+  native sandbox still denies the whole config root.
+- **Session settings live beside the session.** `<session>.settings.json` holds
+  only the fields that differ from global, following the same atomic-write and
+  defensive-load rules as the goal and todo companions. An empty overlay deletes
+  the file rather than leaving a stub beside every session. `/clear` and `/new`
+  start from the global settings, because the overlay belongs to the session
+  that set it.
 - **Null devices and Git Bash drive paths are policy-friendly.** `/dev/null` is
   a null device in every path flavor, so `2>/dev/null` and `> /dev/null` no
   longer classify as external writes on a Windows cwd. A Git Bash / MSYS drive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to PUM are documented in this file.
 ## [Unreleased]
 
 ### Added
+- Added per-agent todo lists. A hidden `Todo` tool group gives the main agent and each managed child `todo_list`, `todo_add`, `todo_update`, `todo_complete` and `todo_delete`, each bound to its own session so no agent can read or change another's plan. Readonly children keep the tools. `Ctrl+O` and `/todo` open a view-only popup for the selected transcript, with `f` to filter.
+- Added `/afk`, which answers model questionnaires while you are away. Each questionnaire goes to one fresh delegate holding a single tool - no files, no shell, no network, no delegation. `/afk` alone toggles it, `/afk <instructions>` starts or re-steers it, and any failure hands the questionnaire straight back to you. AFK is process-local: it is never written to disk and never survives a restart.
+- Added `pum worktree [directory]` and `pum w [directory]`, which create an auto-named worktree under `<repo>/.pum/worktrees` and start a fresh session in it. The source repository stays writable for that process only, without touching your saved `/check-path` settings. Uncommitted source changes are not copied, because creation uses the current commit.
+- Added session-scoped settings. Changes in the Ctrl+P panel now apply to the current session and persist beside it, leaving the global `pum.json` alone; `s` in the panel saves them as the global defaults.
+- Added absolute and home path completion. `/` and `~/` now complete, alongside project-relative paths, with credential paths and symbolic links still excluded.
+
+### Changed
+- No agent can write the PUM config directory any more. The main agent's exact-file allowance for `settings.json`, `pum.json` and `theme.json` is revoked, since settings are session-scoped and only the Settings panel promotes them.
+- An absolute path no longer matches a slash command, so Tab on `/u` completes `/usr/lib` instead of turning it into `/new`.
+
+### Fixed
+- Orphaned `.goal.json` files are swept when a session is deleted. The sweep never knew about them, so one was left behind for every session removed since goals shipped.
+
 - Added an autonomous goal mode. `/goal <text>` stores a goal with the session and starts work at once; `/goalf <draft>` interviews you first and stores nothing until you confirm the one goal it proposes. `/goal stop`, `/goal continue`, `/goal status`, and `/goal clear` control it, and replacing or clearing a goal asks first.
 - Added judge-driven continuation. After a settled main turn, once no managed worker is running and no queued message is waiting, a fresh readonly judge reviews the repository and returns one verdict: complete the goal, ask you a single question, or write the next instruction and start another turn. It holds no worktree, counts as no worker, and is removed after each review.
 - Added a `goalRetryLimit` setting, on the Ctrl+P panel and in `pum.json`. It bounds consecutive incomplete reviews, defaults to 10, accepts 0 through 100, and 0 means no limit.

--- a/src/afk-ui.test.tsx
+++ b/src/afk-ui.test.tsx
@@ -1,0 +1,227 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createTestRenderer } from "@opentui/core/testing";
+import { createRoot } from "@opentui/react";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { App } from "./app";
+import { QuestionnaireManager } from "./questionnaire";
+
+let destroy: (() => void) | undefined;
+afterEach(() => {
+  destroy?.();
+  destroy = undefined;
+});
+
+const settings = {
+  showThinking: false,
+  theme: "tokyonight" as const,
+  animations: false,
+  workingRuleAnimation: "off" as const,
+  webSearch: false,
+  writingStyle: "none" as const,
+  explanationStrength: "simple" as const,
+  checkMode: "off" as const,
+  checkModel: "mock/check",
+  maxActiveSubagents: 10,
+};
+
+function fakeSession() {
+  const path = join(mkdtempSync(join(tmpdir(), "pum-afk-ui-")), "current-session.jsonl");
+  return {
+    agent: {
+      state: {
+        model: { id: "mock-model", provider: "mock", input: ["text"], contextWindow: 32_000 },
+        thinkingLevel: "off",
+      },
+    },
+    sessionManager: { buildContextEntries: () => [], getEntries: () => [] },
+    sessionFile: path,
+    sessionId: "current-session",
+    subscribe: () => () => {},
+    setThinkingLevel() {},
+    setModel: async () => {},
+    clearQueue: () => ({ steering: [], followUp: [] }),
+    abort: async () => {},
+    compact: async () => ({ tokensBefore: 0 }),
+    prompt: async () => {},
+    steer: async () => {},
+  } as any;
+}
+
+async function settle(setup: Awaited<ReturnType<typeof createTestRenderer>>) {
+  await setup.renderOnce();
+  await setup.flush();
+  await new Promise((resolve) => setTimeout(resolve, 40));
+  await setup.renderOnce();
+  await setup.flush();
+}
+
+async function renderApp(questionnaireManager?: QuestionnaireManager, width = 100) {
+  const session = fakeSession();
+  const setup = await createTestRenderer({ width, height: 28, kittyKeyboard: true });
+  destroy = () => setup.renderer.destroy();
+  const spawned: { task: string; onAnswer: (raw: unknown) => void }[] = [];
+  const manager = {
+    getAgents: () => [],
+    subscribe: () => () => {},
+    bindMainSession: async () => {},
+    abortAgent: async () => {},
+    sendUserMessage: async () => {},
+    persistToolEvent() {},
+    appendAgentLine() {},
+    removeAfkDelegate: async () => {},
+    spawnAfkDelegate: async (options: any) => {
+      spawned.push(options);
+      return { id: `afk-${spawned.length}` };
+    },
+  } as any;
+  createRoot(setup.renderer).render(
+    <App
+      session={session}
+      modelRuntime={{ getAvailableSnapshot: () => [], getProviders: () => [] } as any}
+      onNewSession={async () => session}
+      loadSessions={async () => []}
+      onSwitchSession={async () => session}
+      settings={settings}
+      searchProviders={[]}
+      subagentManager={manager}
+      questionnaireManager={questionnaireManager}
+      promptHistoryStore={{ load: () => [], append: () => [], remove: () => [] }}
+      promptStashStore={{
+        load: () => [],
+        append: () => [],
+        markExecuted: () => [],
+        markExecutedMany: () => [],
+        replace: () => [],
+        remove: () => [],
+      }}
+    />,
+  );
+  await settle(setup);
+  return { setup, spawned };
+}
+
+const QUESTIONS = [{
+  id: "q1",
+  prompt: "Which database should the cache use?",
+  options: [
+    { value: "redis", label: "Redis" },
+    { value: "memory", label: "In-memory" },
+  ],
+}];
+
+async function type(setup: Awaited<ReturnType<typeof createTestRenderer>>, text: string) {
+  await setup.mockInput.typeText(text);
+  setup.mockInput.pressEnter();
+  await settle(setup);
+}
+
+describe("/afk in the app", () => {
+  test("toggles on, re-steers, and toggles off", async () => {
+    const { setup } = await renderApp();
+
+    await type(setup, "/afk");
+    expect(setup.captureCharFrame()).toContain("AFK on");
+
+    await type(setup, "/afk prefer the cheaper option");
+    let frame = setup.captureCharFrame();
+    expect(frame).toContain("AFK steered");
+    expect(frame).toContain("prefer the cheaper option");
+
+    await type(setup, "/afk");
+    expect(setup.captureCharFrame()).toContain("AFK off");
+  });
+
+  test("the rule carries AFK, and shares the row with a goal", async () => {
+    const { setup } = await renderApp();
+    await type(setup, "/afk");
+
+    const rows = setup.captureCharFrame().split("\n");
+    // The transcript also says "AFK on", so pick the rule out by its glyphs:
+    // exactly one row carries both, and it is the rule.
+    const ruleRows = rows.filter((row) => row.includes("AFK") && row.includes("─"));
+    expect(ruleRows).toHaveLength(1);
+    // Painted onto the rule, not stacked above it.
+    expect(rows[rows.indexOf(ruleRows[0]!) + 1]).toContain("❯");
+    for (const row of rows) expect(Array.from(row).length).toBeLessThanOrEqual(100);
+  });
+
+  test("a questionnaire goes to a delegate instead of the popup", async () => {
+    const questionnaireManager = new QuestionnaireManager();
+    const { setup, spawned } = await renderApp(questionnaireManager);
+    await type(setup, "/afk");
+
+    const pending = questionnaireManager.request({ id: "main", name: "main" }, QUESTIONS);
+    await settle(setup);
+
+    // The popup must stay down and the delegate must get the exact question.
+    expect(setup.captureCharFrame()).not.toContain("Which database should the cache use?");
+    expect(spawned).toHaveLength(1);
+    expect(spawned[0]!.task).toContain("Which database should the cache use?");
+
+    spawned[0]!.onAnswer({
+      requestId: questionnaireManager.current()!.id,
+      generation: "1",
+      answers: [{ questionId: "q1", value: "redis", label: "Redis", custom: false }],
+    });
+    await settle(setup);
+
+    await expect(pending).resolves.toEqual({
+      cancelled: false,
+      answers: [{ questionId: "q1", value: "redis", label: "Redis", custom: false }],
+    });
+    expect(setup.captureCharFrame()).toContain("AFK answered for main");
+  });
+
+  test("the prompt stays usable while a delegate answers", async () => {
+    const questionnaireManager = new QuestionnaireManager();
+    const { setup } = await renderApp(questionnaireManager);
+    await type(setup, "/afk");
+    void questionnaireManager.request({ id: "main", name: "main" }, QUESTIONS);
+    await settle(setup);
+
+    // Typing /afk must reach the prompt, or there is no way back from AFK.
+    await setup.mockInput.typeText("/afk");
+    await settle(setup);
+    const promptRow = setup.captureCharFrame().split("\n").findLast((row) => row.includes("❯"));
+    expect(promptRow).toContain("/afk");
+  });
+
+  test("stopping AFK hands the unanswered questionnaire back", async () => {
+    const questionnaireManager = new QuestionnaireManager();
+    const { setup } = await renderApp(questionnaireManager);
+    await type(setup, "/afk");
+    void questionnaireManager.request({ id: "main", name: "main" }, QUESTIONS);
+    await settle(setup);
+    expect(setup.captureCharFrame()).not.toContain("Which database should the cache use?");
+
+    await type(setup, "/afk");
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("Which database should the cache use?");
+    // The request survived: it was never answered or cancelled.
+    expect(questionnaireManager.current()?.questions).toHaveLength(1);
+  });
+
+  test("a stale answer from an older AFK run is ignored", async () => {
+    const questionnaireManager = new QuestionnaireManager();
+    const { setup, spawned } = await renderApp(questionnaireManager);
+    await type(setup, "/afk");
+    void questionnaireManager.request({ id: "main", name: "main" }, QUESTIONS);
+    await settle(setup);
+    const requestId = questionnaireManager.current()!.id;
+
+    await type(setup, "/afk");
+    await type(setup, "/afk");
+    await settle(setup);
+
+    // Generation 1 belongs to the AFK run the user already stopped.
+    spawned[0]!.onAnswer({
+      requestId,
+      generation: "1",
+      answers: [{ questionId: "q1", value: "redis", label: "Redis", custom: false }],
+    });
+    await settle(setup);
+    expect(setup.captureCharFrame()).not.toContain("AFK answered");
+  });
+});

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -79,6 +79,19 @@ import {
   withSearchRoute,
 } from "./web-search";
 import { matchingCommands, moveCommandSelection } from "./commands";
+import { truncateStatusText } from "./status-metadata";
+import { modeLineLabels } from "./mode-line";
+import { AfkController, type AfkStatus } from "./afk";
+import { parseAfkCommand } from "./afk-command";
+import {
+  afkAnswerFailureText,
+  buildAfkTask,
+  validateAfkAnswer,
+} from "./afk-delegate";
+import type {
+  QuestionnaireRequest,
+  QuestionnaireResult,
+} from "./questionnaire";
 import { loadTodoTasks } from "./todo";
 import {
   cycleTodoFilter,
@@ -340,7 +353,7 @@ function WorkingRule({
   dimmed?: boolean;
   mode: WorkingRuleAnimationMode;
   role: WorkingRuleRole;
-  label?: WorkingRuleLabel | null;
+  label?: WorkingRuleLabel | readonly WorkingRuleLabel[] | null;
 }) {
   const ref = useWorkingRule({
     width,
@@ -725,12 +738,6 @@ export function App({
   const animations = settings.animations && supportsTrueColor();
   // The goal rides the input-top rule, not the status bar. It is rebuilt only
   // when the goal, the terminal width, or the theme changes.
-  const goalRuleLabel = useMemo<WorkingRuleLabel | null>(() => {
-    const label = goalLabel(goal, Math.max(0, width));
-    return label
-      ? { text: label.text, width: label.width, color: goalLabelColor(theme, label.state) }
-      : null;
-  }, [goal?.text, goal?.state, width, theme]);
   const agents = subagentManager.getAgents();
   const activeSubagentCount = countActiveSubagents(agents);
   // Layout effect, like the transcript mirror: an event handler can read this
@@ -743,11 +750,37 @@ export function App({
     : undefined;
   const questionnaire = questionnaireManager?.current();
   const spawnPreview = spawnPreviewManager?.current();
+  // One controller for the process. It lives in a ref so /clear, session
+  // switches and transcript switches leave it alone; only an explicit toggle,
+  // or the process ending, can stop AFK.
+  const afkRef = useRef<AfkController | undefined>(undefined);
+  afkRef.current ??= new AfkController();
+  const afk = afkRef.current;
+  const [afkStatus, setAfkStatus] = useState<AfkStatus>(() => afk.status());
+  useEffect(() => afk.subscribe(() => setAfkStatus(afk.status())), [afk]);
+
+  // While a delegate answers, the popup stays down but the prompt stays live,
+  // so the user can always type /afk to take the questionnaire back.
+  const afkAnswering = Boolean(questionnaire) && afkStatus.active;
+  const visibleQuestionnaire = afkAnswering ? undefined : questionnaire;
+
+  const ruleLabels = useMemo<WorkingRuleLabel[]>(() => modeLineLabels({
+    goal,
+    afk: afkStatus.active
+      ? { state: afkAnswering ? "answering" : "on", instructions: afkStatus.instructions }
+      : null,
+    ruleWidth: Math.max(0, width),
+    theme,
+  }), [
+    goal?.text, goal?.state, width, theme,
+    afkStatus.active, afkStatus.instructions, afkAnswering,
+  ]);
+
   // Every other popup outranks this one. Deriving visibility instead of closing
   // it from each opener means a popup added later cannot forget a line here.
   const todoVisible = todoOpen
     && !settingsOpen && !helpOpen && !historyOpen && !statsOpen && !agentSelectorOpen
-    && !triggersOpen && !loginOpen && !newsOpen && !questionnaire && !spawnPreview;
+    && !triggersOpen && !loginOpen && !newsOpen && !visibleQuestionnaire && !spawnPreview;
   const visibleTx = transcriptForThinkingVisibility(
     activeAgent?.transcript ?? tx,
     settings.showThinking,
@@ -2032,6 +2065,146 @@ export function App({
     applyTodoSelection(null);
   };
 
+  /** The transcript of whoever asked, so the delegate decides with their context. */
+  const transcriptForRequester = (requesterId: string) => {
+    if (requesterId === "main") return txRef.current;
+    return agents.find((agent) => agent.id === requesterId)?.transcript ?? txRef.current;
+  };
+
+  /**
+   * A durable row in the requesting agent's transcript for every automatic
+   * answer. The questionnaire tool result already carries the answers, so this
+   * is for the user only and never re-enters the model's context.
+   */
+  const appendAfkAudit = (request: QuestionnaireRequest, result: QuestionnaireResult) => {
+    const lines = request.questions.map((question) => {
+      const answer = result.answers.find((entry) => entry.questionId === question.id);
+      const asked = question.label ?? question.prompt;
+      const flat = asked.replace(/\s+/g, " ").trim();
+      return `  ${truncateStatusText(flat, 60) ?? flat} → ${answer?.label ?? "?"}`;
+    });
+    const row = {
+      kind: "text" as const,
+      role: "system" as const,
+      text: [`AFK answered for ${request.requester.name}`, ...lines].join("\n"),
+    };
+    if (request.requester.id === "main") appendMainLine(row);
+    else subagentManager.appendAgentLine(request.requester.id, row);
+  };
+
+  const afkDelegateRef = useRef<{
+    id: string | null;
+    requestId: string;
+    generation: number;
+    settled: boolean;
+  } | null>(null);
+  const afkStartingRef = useRef(false);
+
+  const stopAfkDelegate = async () => {
+    const running = afkDelegateRef.current;
+    afkDelegateRef.current = null;
+    if (running?.id) await subagentManager.removeAfkDelegate(running.id).catch(() => {});
+  };
+
+  /**
+   * Give up on automatic answers and hand the questionnaire back.
+   *
+   * Every failure path lands here rather than retrying: a delegate that cannot
+   * answer once is unlikely to answer better twice, and the user is the safe
+   * fallback. The original request is untouched, so its popup simply reappears.
+   */
+  const surrenderAfk = (reason: string) => {
+    void stopAfkDelegate();
+    afk.stop();
+    appendMainLine({ kind: "text", role: "error", text: `AFK off: ${reason}` });
+  };
+
+  const processAfkAnswer = async (
+    ticket: { requestId: string; generation: number },
+    raw: unknown,
+  ) => {
+    const running = afkDelegateRef.current;
+    // Stale on any count: a newer request, a newer AFK run, or an answer that
+    // arrived after the user already took over.
+    if (!running || running.settled) return;
+    if (running.requestId !== ticket.requestId || running.generation !== ticket.generation) return;
+    if (afk.generation() !== ticket.generation) return;
+    running.settled = true;
+
+    const request = questionnaireManager?.current();
+    if (!request || request.id !== ticket.requestId) {
+      await stopAfkDelegate();
+      return;
+    }
+    const outcome = validateAfkAnswer(request, String(ticket.generation), raw);
+    if (!outcome.ok) {
+      surrenderAfk(afkAnswerFailureText(outcome.failure));
+      return;
+    }
+    const accepted = questionnaireManager?.completeCurrent(request.id, outcome.result) ?? false;
+    await stopAfkDelegate();
+    if (!accepted) return;
+    appendAfkAudit(request, outcome.result);
+  };
+
+  const startAfkDelegate = async (request: QuestionnaireRequest) => {
+    const begun = afk.begin();
+    if (!begun) return;
+    afkStartingRef.current = true;
+    const ticket = { requestId: request.id, generation: begun.generation };
+    afkDelegateRef.current = { id: null, requestId: request.id, generation: begun.generation, settled: false };
+    try {
+      const task = buildAfkTask({
+        request,
+        guidance: begun.guidance,
+        requesterName: request.requester.name,
+        context: judgeTranscript(transcriptForRequester(request.requester.id).lines),
+        generation: String(begun.generation),
+      });
+      const agent = await subagentManager.spawnAfkDelegate({
+        task,
+        modelId: session.agent.state.model.id,
+        thinkingLevel: String(session.agent.state.thinkingLevel),
+        onAnswer: (raw) => void processAfkAnswer(ticket, raw),
+      });
+      if (afkDelegateRef.current?.requestId === request.id) afkDelegateRef.current.id = agent.id;
+      else await subagentManager.removeAfkDelegate(agent.id).catch(() => {});
+    } catch (error) {
+      surrenderAfk(`the delegate could not start (${String(error)})`);
+    } finally {
+      afkStartingRef.current = false;
+    }
+  };
+
+  const runAfkCommand = (text: string): boolean => {
+    const command = parseAfkCommand(text);
+    if (!command) return false;
+    if (command.kind === "error") {
+      // Keep the draft: the user still has to fix it.
+      setEditorText(text, text.length, true);
+      appendMainLine({ kind: "text", role: "error", text: command.message });
+      return true;
+    }
+    const result = command.kind === "toggle" ? afk.toggle() : afk.toggle(command.text);
+    if (result.kind === "rejected") {
+      setEditorText(text, text.length, true);
+      appendMainLine({ kind: "text", role: "error", text: result.message });
+      return true;
+    }
+    if (result.kind === "stopped") {
+      void stopAfkDelegate();
+      appendMainLine({ kind: "text", role: "system", text: "AFK off." });
+      return true;
+    }
+    const verb = result.kind === "started" ? "on" : "steered";
+    appendMainLine({
+      kind: "text",
+      role: "system",
+      text: result.instructions ? `AFK ${verb}: ${result.instructions}` : `AFK ${verb}.`,
+    });
+    return true;
+  };
+
   const openTodo = () => {
     settingsOpenRef.current = false;
     setSettingsOpen(false);
@@ -2967,6 +3140,14 @@ export function App({
       return;
     }
 
+    // AFK is process-global, so it is intercepted above the child routing below.
+    // Anything past that point belongs to one transcript, and /afk belongs to
+    // none of them - including keeping its instructions out of prompt history.
+    if (attachments.length === 0 && runAfkCommand(promptText)) {
+      setEditorText("");
+      return;
+    }
+
     if (selectedAgentId) {
       void subagentManager
         .sendUserMessage(selectedAgentId, promptText, images, displayText)
@@ -3310,9 +3491,9 @@ export function App({
       return;
     }
 
-    if (key.ctrl && key.name === "c" && questionnaire) {
+    if (key.ctrl && key.name === "c" && visibleQuestionnaire) {
       key.stopPropagation();
-      if (questionnaire.customInput) {
+      if (visibleQuestionnaire.customInput) {
         questionnaireInputRef.current?.setText("");
         questionnaireManager?.cancelCustom();
       } else {
@@ -3368,7 +3549,7 @@ export function App({
       key.stopPropagation();
       resetCancelArm();
       const promptOwnsInput =
-        !questionnaire &&
+        !visibleQuestionnaire &&
         !spawnPreview &&
         !loginOpen &&
         !triggersOpenRef.current &&
@@ -3400,13 +3581,13 @@ export function App({
     if (lastQuitPress.current) resetQuitArm();
     if (key.name !== "escape" && lastCancelPress.current !== null) resetCancelArm();
 
-    if (questionnaire) {
+    if (visibleQuestionnaire) {
       const isQuestionnaireReturn =
         key.name === "return" ||
         key.name === "enter" ||
         key.name === "kpenter" ||
         key.name === "linefeed";
-      if (questionnaire.customInput) {
+      if (visibleQuestionnaire.customInput) {
         if (key.name === "escape") {
           key.stopPropagation();
           questionnaireInputRef.current?.setText("");
@@ -4045,6 +4226,20 @@ export function App({
   // Reset keys for the render boundaries: a shown error clears as soon as the
   // transcript or the open popup changes, so the next state gets a fresh try.
   const transcriptResetKey = `${activeAgentId ?? "main"}:${visibleLines.length}`;
+  useEffect(() => {
+    if (!afkStatus.active || !questionnaire) return;
+    if (afkStartingRef.current) return;
+    // One delegate in flight. The next queued request starts only once this
+    // one has durably resolved, which is what clearing the ref means.
+    if (afkDelegateRef.current) return;
+    void startAfkDelegate(questionnaire);
+  }, [afkStatus.active, afkStatus.generation, questionnaire?.id]);
+
+  useEffect(() => {
+    // The user took AFK off, or the request went away under the delegate.
+    if (!afkStatus.active && afkDelegateRef.current) void stopAfkDelegate();
+  }, [afkStatus.active]);
+
   const popupResetKey = [
     loginOpen, spawnPreview?.id ?? "", Boolean(questionnaire), helpOpen, triggersOpen,
     agentSelectorOpen, historyOpen, newsOpen, todoVisible, statsOpen, settingsOpen, page,
@@ -4199,7 +4394,7 @@ export function App({
           dimmed={stashOpen}
           mode={settings.workingRuleAnimation}
           role="inputTop"
-          label={goalRuleLabel}
+          label={ruleLabels}
         />
         {stashOpen ? (
           <PromptStash
@@ -4273,7 +4468,7 @@ export function App({
             selectionBg={theme.selectionBg}
             wrapMode="word"
             scrollMargin={1}
-            focused={!settingsOpen && !helpOpen && !historyOpen && !statsOpen && !agentSelectorOpen && !triggersOpen && !loginOpen && !questionnaire && !spawnPreview && !newsOpen && !todoVisible}
+            focused={!settingsOpen && !helpOpen && !historyOpen && !statsOpen && !agentSelectorOpen && !triggersOpen && !loginOpen && !visibleQuestionnaire && !spawnPreview && !newsOpen && !todoVisible}
             onContentChange={handleTextareaChange}
             onCursorChange={scheduleInputMetrics}
             onSubmit={() => submitPrompt()}
@@ -4312,10 +4507,10 @@ export function App({
               inputRef={spawnPreviewInputRef}
             />
           ) : null}
-          {questionnaire ? (
+          {visibleQuestionnaire ? (
             <QuestionnairePopup
               theme={theme}
-              request={questionnaire}
+              request={visibleQuestionnaire}
               terminalWidth={width}
               terminalHeight={height}
               inputRef={questionnaireInputRef}

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -35,6 +35,7 @@ import {
   MAX_ACTIVE_SUBAGENTS,
   MIN_ACTIVE_SUBAGENTS,
   SANDBOX_MODES,
+  normalizeSettings,
   saveSettings,
   WORKING_RULE_ANIMATION_MODES,
   type PumSettings,
@@ -81,6 +82,13 @@ import {
 import { matchingCommands, moveCommandSelection } from "./commands";
 import { truncateStatusText } from "./status-metadata";
 import { modeLineLabels } from "./mode-line";
+import {
+  loadSessionSettings,
+  mergeSessionSettings,
+  saveSessionSettings,
+  sessionSettingsDiff,
+  type SessionSettings,
+} from "./session-settings";
 import { AfkController, type AfkStatus } from "./afk";
 import { parseAfkCommand } from "./afk-command";
 import {
@@ -666,7 +674,18 @@ export function App({
   const [settingsQuery, setSettingsQuery] = useState("");
   const [settingsSearchFocused, setSettingsSearchFocused] = useState(true);
   const [selectedSettingId, setSelectedSettingId] = useState<SettingRowId | null>(SETTINGS_ROWS[0]!.id);
-  const [settings, setSettings] = useState(initial);
+  // `initial` is the global config. A session lays its own overrides over it,
+  // so both have to be tracked: one to write back on `s`, one to persist here.
+  // Normalize the baseline: comparing raw props against normalized state would
+  // report every default the normalizer filled in as a session override.
+  const globalSettingsRef = useRef(normalizeSettings(initial));
+  const [sessionOverrides, setSessionOverrides] = useState<SessionSettings>(
+    () => loadSessionSettings(initialSession.sessionFile),
+  );
+  const sessionOverridesRef = useRef(sessionOverrides);
+  const [settings, setSettings] = useState(
+    () => mergeSessionSettings(globalSettingsRef.current, sessionOverridesRef.current),
+  );
   // Mirrors settings for update(): a keypress or an async .then can fire a
   // second update before React commits the first, so update() must build the
   // next value from the latest pending settings, not the render closure.
@@ -1562,6 +1581,14 @@ export function App({
     // companion file, so the old goal cannot follow the user into it.
     clearGoalJudge();
     goalFormulationRef.current = null;
+    // Settings belong to one session too, so /clear and /new fall back to the
+    // global defaults rather than carrying the old session's overrides in.
+    const loadedOverrides = loadSessionSettings(session.sessionFile);
+    sessionOverridesRef.current = loadedOverrides;
+    setSessionOverrides(loadedOverrides);
+    const mergedSettings = mergeSessionSettings(globalSettingsRef.current, loadedOverrides);
+    settingsRef.current = mergedSettings;
+    setSettings(mergedSettings);
     const loadedGoal = loadGoal(session.sessionFile);
     goalRef.current = loadedGoal;
     setGoalState(loadedGoal);
@@ -1888,7 +1915,24 @@ export function App({
     if (patch.maxActiveSubagents !== undefined) {
       subagentManager.setMaxActiveSubagents(patch.maxActiveSubagents);
     }
+    // Session-scoped: the popup never writes the global config, which the
+    // sandboxes keep read-only. `s` in the popup is the one way to promote.
+    const overrides = sessionSettingsDiff(globalSettingsRef.current, next);
+    sessionOverridesRef.current = overrides;
+    setSessionOverrides(overrides);
+    saveSessionSettings(session.sessionFile, overrides);
+  };
+
+  /** Promote this session's settings to the global defaults, on `s` in the popup. */
+  const promoteSessionSettings = () => {
+    const next = settingsRef.current;
+    globalSettingsRef.current = next;
     saveSettings(next);
+    // Nothing differs from global any more, so the session owns no overrides.
+    sessionOverridesRef.current = {};
+    setSessionOverrides({});
+    saveSessionSettings(session.sessionFile, {});
+    appendMainLine({ kind: "text", role: "system", text: "Saved these settings as the global defaults." });
   };
 
   const stepThinking = (step: number) => {
@@ -3870,6 +3914,12 @@ export function App({
       }
 
       key.stopPropagation();
+      // Reachable only with the search unfocused, so `s` never eats a keystroke
+      // meant for the filter.
+      if (printableKeyCharacter(key.name, key.sequence, key.raw) === "s") {
+        promoteSessionSettings();
+        return;
+      }
       const action = selectedSettingId ? rowActions[selectedSettingId] : undefined;
       const confirming = key.name === "space" || key.sequence === " " || isSettingsReturn;
       if (key.name === "up" || key.name === "down") {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -79,6 +79,15 @@ import {
   withSearchRoute,
 } from "./web-search";
 import { matchingCommands, moveCommandSelection } from "./commands";
+import { loadTodoTasks } from "./todo";
+import {
+  cycleTodoFilter,
+  moveTodoSelection,
+  TodoPopup,
+  todoPopupLayout,
+  visibleTodoTasks,
+  type TodoFilter,
+} from "./todo-popup";
 import { applyPathCompletion, pathCompletions, type PathCompletion } from "./path-autocomplete";
 import { isRejectedToolResult, rejectedToolReason } from "./check-mode";
 import { SessionHistoryPopup } from "./session-history-popup";
@@ -695,6 +704,12 @@ export function App({
   const [shellTails, setShellTails] = useState<Record<string, string>>({});
 
   const [newsOpen, setNewsOpen] = useState(false);
+  const [todoOpen, setTodoOpen] = useState(false);
+  const todoOpenRef = useRef(false);
+  const [todoFilter, setTodoFilter] = useState<TodoFilter>("all");
+  const todoFilterRef = useRef<TodoFilter>("all");
+  const [todoSelectedId, setTodoSelectedId] = useState<string | null>(null);
+  const todoSelectedIdRef = useRef<string | null>(null);
   const newsOpenRef = useRef(false);
   const [newsCursor, setNewsCursor] = useState(0);
   const newsCursorRef = useRef(0);
@@ -728,6 +743,11 @@ export function App({
     : undefined;
   const questionnaire = questionnaireManager?.current();
   const spawnPreview = spawnPreviewManager?.current();
+  // Every other popup outranks this one. Deriving visibility instead of closing
+  // it from each opener means a popup added later cannot forget a line here.
+  const todoVisible = todoOpen
+    && !settingsOpen && !helpOpen && !historyOpen && !statsOpen && !agentSelectorOpen
+    && !triggersOpen && !loginOpen && !newsOpen && !questionnaire && !spawnPreview;
   const visibleTx = transcriptForThinkingVisibility(
     activeAgent?.transcript ?? tx,
     settings.showThinking,
@@ -1306,6 +1326,7 @@ export function App({
       helpOpen ||
       historyOpen ||
       newsOpenRef.current ||
+      todoOpenRef.current ||
       statsOpenRef.current ||
       settingsOpenRef.current
     ) return;
@@ -1956,6 +1977,8 @@ export function App({
     setLoginOpen(false);
     setStatsOpen(false);
     statsOpenRef.current = false;
+    todoOpenRef.current = false;
+    setTodoOpen(false);
     newsCursorRef.current = 0;
     setNewsCursor(0);
     newsOpenRef.current = true;
@@ -1965,6 +1988,69 @@ export function App({
   const closeNews = () => {
     newsOpenRef.current = false;
     setNewsOpen(false);
+    queueMicrotask(() => inputRef.current?.focus());
+  };
+
+  // Re-read on every transcript change while the popup is open: a todo tool call
+  // always adds a line, so the list follows the agent without an event bus.
+  const todoSessionFile = activeAgent?.sessionFile ?? session.sessionFile;
+  const todoTasks = useMemo(
+    () => (todoVisible ? visibleTodoTasks(loadTodoTasks(todoSessionFile), todoFilter) : []),
+    [todoVisible, todoSessionFile, todoFilter, visibleLines.length, visibleBusy],
+  );
+  const todoPageSize = Math.max(1, todoPopupLayout(width, height).listHeight);
+
+  const applyTodoSelection = (next: string | null) => {
+    todoSelectedIdRef.current = next;
+    setTodoSelectedId(next);
+  };
+
+  const moveTodoCursor = (step: number) => {
+    if (todoTasks.length === 0) return;
+    const current = todoSelectedIdRef.current;
+    const index = todoTasks.findIndex((task) => task.id === current);
+    const from = index < 0 ? 0 : index;
+    const to = Math.min(todoTasks.length - 1, Math.max(0, from + step));
+    // Single steps wrap, a page jump clamps: paging past the end should land on
+    // the end, not on the row the user started from.
+    const wrapped = Math.abs(step) === 1
+      ? moveTodoSelection(todoTasks, current, step as -1 | 1)
+      : todoTasks[to]?.id ?? null;
+    applyTodoSelection(wrapped);
+  };
+
+  const moveTodoCursorTo = (edge: "first" | "last") => {
+    if (todoTasks.length === 0) return;
+    applyTodoSelection((edge === "first" ? todoTasks[0] : todoTasks.at(-1))?.id ?? null);
+  };
+
+  const cycleTodoFilterState = () => {
+    const next = cycleTodoFilter(todoFilterRef.current);
+    todoFilterRef.current = next;
+    setTodoFilter(next);
+    // The old selection may not survive the new filter; let the popup reseat it.
+    applyTodoSelection(null);
+  };
+
+  const openTodo = () => {
+    settingsOpenRef.current = false;
+    setSettingsOpen(false);
+    setHelpOpen(false);
+    setHistoryOpen(false);
+    setAgentSelectorOpen(false);
+    setTriggerPopup(false, false);
+    setLoginOpen(false);
+    setStatsOpen(false);
+    statsOpenRef.current = false;
+    newsOpenRef.current = false;
+    setNewsOpen(false);
+    todoOpenRef.current = true;
+    setTodoOpen(true);
+  };
+
+  const closeTodo = () => {
+    todoOpenRef.current = false;
+    setTodoOpen(false);
     queueMicrotask(() => inputRef.current?.focus());
   };
 
@@ -2291,9 +2377,10 @@ export function App({
     const triggersCommand = trimmed === "/triggers";
     const processesCommand = trimmed === "/processes";
     const newsCommand = trimmed === "/news";
+    const todoCommand = trimmed === "/todo";
     const statsCommand = trimmed === "/stats";
     const worktreeCommand = /^\/worktree(?:\s+([a-zA-Z0-9_-]+))?$/.exec(trimmed);
-    if (!compress && !clear && !historyCommand && !loginCommand && !checkPathCommand && !triggersCommand && !processesCommand && !newsCommand && !statsCommand && !worktreeCommand) return false;
+    if (!compress && !clear && !historyCommand && !loginCommand && !checkPathCommand && !triggersCommand && !processesCommand && !newsCommand && !todoCommand && !statsCommand && !worktreeCommand) return false;
     setEditingStash(null);
 
     if (historyCommand) {
@@ -2319,6 +2406,11 @@ export function App({
     if (newsCommand) {
       setEditorText("");
       openNews();
+      return true;
+    }
+    if (todoCommand) {
+      setEditorText("");
+      openTodo();
       return true;
     }
     if (statsCommand) {
@@ -3516,6 +3608,25 @@ export function App({
       return;
     }
 
+    if (key.ctrl && printableKey === "o") {
+      key.stopPropagation();
+      if (todoOpenRef.current) closeTodo();
+      else openTodo();
+      return;
+    }
+    if (todoVisible) {
+      key.stopPropagation();
+      if (key.name === "escape") closeTodo();
+      else if (key.name === "up") moveTodoCursor(-1);
+      else if (key.name === "down") moveTodoCursor(1);
+      else if (key.name === "pageup") moveTodoCursor(-todoPageSize);
+      else if (key.name === "pagedown") moveTodoCursor(todoPageSize);
+      else if (key.name === "home") moveTodoCursorTo("first");
+      else if (key.name === "end") moveTodoCursorTo("last");
+      else if (printableKey === "f") cycleTodoFilterState();
+      return;
+    }
+
     // `?` on an empty prompt opens help instead of typing a question mark.
     // With text already in the line it is just a character.
     if (key.sequence === "?" && !settingsOpen && !inputRef.current?.plainText) {
@@ -3936,7 +4047,7 @@ export function App({
   const transcriptResetKey = `${activeAgentId ?? "main"}:${visibleLines.length}`;
   const popupResetKey = [
     loginOpen, spawnPreview?.id ?? "", Boolean(questionnaire), helpOpen, triggersOpen,
-    agentSelectorOpen, historyOpen, newsOpen, statsOpen, settingsOpen, page,
+    agentSelectorOpen, historyOpen, newsOpen, todoVisible, statsOpen, settingsOpen, page,
   ].join(":");
   const streamGap = visibleTx.stream
     ? needsTranscriptGap(lastLine, { kind: "text", role: visibleTx.stream.kind, text: visibleTx.stream.text })
@@ -4162,7 +4273,7 @@ export function App({
             selectionBg={theme.selectionBg}
             wrapMode="word"
             scrollMargin={1}
-            focused={!settingsOpen && !helpOpen && !historyOpen && !statsOpen && !agentSelectorOpen && !triggersOpen && !loginOpen && !questionnaire && !spawnPreview && !newsOpen}
+            focused={!settingsOpen && !helpOpen && !historyOpen && !statsOpen && !agentSelectorOpen && !triggersOpen && !loginOpen && !questionnaire && !spawnPreview && !newsOpen && !todoVisible}
             onContentChange={handleTextareaChange}
             onCursorChange={scheduleInputMetrics}
             onSubmit={() => submitPrompt()}
@@ -4255,6 +4366,17 @@ export function App({
               cursor={newsCursor}
               terminalWidth={width}
               terminalHeight={height}
+            />
+          ) : null}
+          {todoVisible ? (
+            <TodoPopup
+              theme={theme}
+              terminalWidth={width}
+              terminalHeight={height}
+              agentName={activeAgent?.name ?? "main"}
+              tasks={todoTasks}
+              filter={todoFilter}
+              selectedId={todoSelectedId}
             />
           ) : null}
           {statsOpen ? (

--- a/src/check-mode.test.ts
+++ b/src/check-mode.test.ts
@@ -447,6 +447,26 @@ describe("PUM settings-file scope and identity gating", () => {
     expect(verifier.calls).toBe(0);
   });
 
+  test("blocks a main settings-file write when no allowance is granted", async () => {
+    // Nothing in PUM grants one any more: settings changes belong to the
+    // session, and only the Settings popup promotes them to global.
+    const cwd = tempProject("pum-settings-project-");
+    const settingsDir = tempProject("pum-settings-dir-");
+    const verifier = runtime([]);
+    const command = `printf '{}' > '${join(settingsDir, "pum.json")}'`;
+
+    // The identical call with an explicit allowance is allowed above, so this
+    // isolates the allowance itself rather than the external-write rule.
+    expect(await evaluateToolCall(verifier, {
+      toolName: "bash", input: { command }, cwd, config, requester: { kind: "main" },
+    })).toMatchObject({ decision: "block" });
+    expect(await evaluateToolCall(verifier, {
+      toolName: "bash", input: { command }, cwd, config, requester: { kind: "main" },
+      settingsFiles: settingsNames.map((name) => join(settingsDir, name)),
+    })).toMatchObject({ decision: "allow" });
+    expect(verifier.calls).toBe(0);
+  });
+
   test("keeps auth.json and session writes blocked for main even with settings enabled", async () => {
     const cwd = tempProject("pum-settings-project-");
     const settingsDir = tempProject("pum-settings-dir-");

--- a/src/check-mode.ts
+++ b/src/check-mode.ts
@@ -3,7 +3,7 @@ import type { InlineExtension, ModelRuntime } from "@earendil-works/pi-coding-ag
 import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { AGENT_DIR, settingsFilePaths } from "./config";
+import { AGENT_DIR } from "./config";
 import { projectStorageKey } from "./platform";
 import {
   canonicalJson,
@@ -622,9 +622,11 @@ export async function evaluateToolCall(runtime: CheckerRuntime, call: ToolCheck)
   const config = normalizeConfig(call.config);
   if (config.profile === "off") return { decision: "allow", reason: "Check mode is off", category: "off" };
   if (call.signal?.aborted) return { decision: "block", reason: "Safety check aborted", category: "abort" };
-  const settingsFiles = call.requester?.kind === "main"
-    ? call.settingsFiles ?? settingsFilePaths()
-    : [];
+  // No agent writes the config directory any more. Settings changes belong to
+  // the session, and `s` in the Settings popup is the one deliberate promotion
+  // to global - done by PUM itself, not through a tool. The mechanism stays so
+  // an exact-file allowance can be granted deliberately, but nothing grants one.
+  const settingsFiles = call.requester?.kind === "main" ? call.settingsFiles ?? [] : [];
   const preparedResult = await prepareCheck(
     call.toolName,
     call.input,

--- a/src/commands.test.ts
+++ b/src/commands.test.ts
@@ -33,3 +33,20 @@ describe("command suggestions", () => {
     expect(matchingCommands("/clear\nkeep this text")).toEqual([]);
   });
 });
+
+describe("absolute paths are not commands", () => {
+  test("a second separator ends command matching, so paths complete instead", () => {
+    // /c still reaches /clear and /compress; /c/ is a path the user is typing.
+    expect(matchingCommands("/c").length).toBeGreaterThan(0);
+    expect(matchingCommands("/c/")).toEqual([]);
+    expect(matchingCommands("/usr/l")).toEqual([]);
+    expect(matchingCommands("/n/ew")).toEqual([]);
+    expect(matchingCommands("/etc/hosts")).toEqual([]);
+  });
+
+  test("a separator after the command name still matches the command", () => {
+    // The rule looks at the first token only, so an argument may hold a path.
+    expect(matchingCommands("/check-path /usr/lib").map((command) => command.name))
+      .toEqual(["/check-path"]);
+  });
+});

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -38,6 +38,10 @@ export const COMMANDS: Command[] = [
     description: "Open recent answers (News)",
   },
   {
+    name: "/todo",
+    description: "Show the selected agent's todo list",
+  },
+  {
     name: "/stats",
     description: "Show session statistics",
   },
@@ -62,6 +66,10 @@ export const COMMANDS: Command[] = [
 export function matchingCommands(input: string): Command[] {
   if (!input.startsWith("/") || input.includes("\n")) return [];
   const name = input.split(/\s/, 1)[0]!;
+  // No command name holds a second separator, so one means the user is typing
+  // an absolute path. Leaving it to prefix matching would let Tab on /u turn
+  // /usr/lib into /new.
+  if (/[/\\]/.test(name.slice(1))) return [];
   return COMMANDS.filter((command) =>
     /\s/.test(input) ? command.name === name : command.name.startsWith(input),
   );

--- a/src/help-popup.tsx
+++ b/src/help-popup.tsx
@@ -61,6 +61,7 @@ export const HELP_GROUPS: HelpGroup[] = [
       ["/history", "Browse saved sessions"],
       ["/login", "Add or update a provider"],
       ["/news", "Open recent answers (News)"],
+      ["/todo", "Show the agent's todo list"],
       ["/stats", "Show session statistics"],
       ["/check-path", "Manage extra Check mode paths"],
       ["/processes", "Open Processes on last tab"],
@@ -74,6 +75,7 @@ export const HELP_GROUPS: HelpGroup[] = [
     controls: [
       ["Ctrl+P", "Open Settings"],
       ["Ctrl+N", "Open News; n answer / p source"],
+      ["Ctrl+O", "Open the agent's todo list"],
       ["Ctrl+T", "Open Processes"],
       ["Ctrl+End", "Scroll transcript to the end"],
       ["/ in Settings", "Focus the settings search"],

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -47,6 +47,7 @@ import {
   systemTriggerClock,
 } from "./triggers/process";
 import type { StartupOptions } from "./cli";
+import { TodoToolsController } from "./todo-tools";
 import { installSelectionClipboard } from "./clipboard";
 import { TerminalTitleController } from "./terminal-title";
 import { SandboxController } from "./sandbox";
@@ -113,6 +114,7 @@ export async function start(
   const questionnaireManager = new QuestionnaireManager();
   const spawnPreviewManager = new SpawnPreviewManager();
   const mainToolGroups = new ToolGroupsController("main");
+  const mainTodoTools = new TodoToolsController("main");
   const sessionHistoryIndex = new SessionHistoryIndex();
   const messageCacheController = new MessageCacheController(process.cwd());
   const statsManager = new SessionStatsManager();
@@ -276,6 +278,7 @@ export async function start(
             applyPatchExtension,
             questionnaireManager.extension({ id: "main", name: "main" }),
             mainToolGroups.extension(),
+            mainTodoTools.extension(),
             subagentExtension,
           ],
         },
@@ -284,6 +287,9 @@ export async function start(
       // the session file. Restore before enable_tools registers and runs, then
       // narrow the outgoing tool list to core plus enabled groups.
       mainToolGroups.load(sessionManager.getSessionFile());
+      // Bind the list to this session before any tool can run, so a resumed
+      // session reads its own plan and /clear starts an empty one.
+      mainTodoTools.load(sessionManager.getSessionFile());
       const result = await createAgentSessionFromServices({
         services,
         sessionManager,

--- a/src/replay.ts
+++ b/src/replay.ts
@@ -11,6 +11,7 @@ import {
   AGENT_MESSAGE_CUSTOM_TYPE,
   AGENT_MESSAGE_DISPLAY_TYPE,
   SUBAGENT_WAKE_PREFIX,
+  AGENT_NOTICE_CUSTOM_TYPE,
   TOOL_EVENT_CUSTOM_TYPE,
   TRIGGER_EVENT_CUSTOM_TYPE,
   type AgentMessageData,
@@ -123,6 +124,15 @@ function managedShellReplayText(event: ManagedShellLifecycleEvent): string {
     : `${label} exited with ${result}.`;
 }
 
+/** A display-only notice PUM wrote into a transcript. Never model context. */
+function agentNoticeOf(entry: any): Line | undefined {
+  if (entry?.type !== "custom" || entry.customType !== AGENT_NOTICE_CUSTOM_TYPE) return undefined;
+  const line = entry.data?.line;
+  if (!line || typeof line.text !== "string" || line.kind !== "text") return undefined;
+  const role = line.role === "error" ? "error" : "system";
+  return { kind: "text", role, text: line.text };
+}
+
 function toolEventOf(entry: any): ToolCall | undefined {
   if (entry?.type !== "custom" || entry.customType !== TOOL_EVENT_CUSTOM_TYPE) return undefined;
   const data = entry.data;
@@ -211,6 +221,12 @@ export function replayEntries(
           text: triggerEvent.text,
         });
       }
+      continue;
+    }
+
+    const notice = agentNoticeOf(entry);
+    if (notice) {
+      lines.push(notice);
       continue;
     }
 

--- a/src/sandbox-policy.test.ts
+++ b/src/sandbox-policy.test.ts
@@ -313,3 +313,31 @@ describe("expanded credential and injection denials", () => {
     })).toEqual({ HOME: "/home/user", PATH: "/bin" });
   });
 });
+
+describe("the PUM config directory", () => {
+  test("is denied outright, so no backend can grant it a write", () => {
+    // Settings are session-scoped and PUM promotes them itself. No agent, in
+    // either sandbox, has a reason to write here - and the deterministic layer
+    // no longer grants an exact-file allowance either.
+    const command = "echo hi";
+    const policy = buildSandboxPolicy({
+      command,
+      cwd: "/work/repo",
+      executable: "/bin/bash",
+      args: ["-c", command],
+      privateTemp: "/tmp/private",
+      pumConfigRoot: "/pum",
+      home: "/home/user",
+      platform: "linux",
+      result: analyzeCheckPolicy({
+        command,
+        cwd: "/work/repo",
+        profile: "balanced",
+        fileSystem: inertFileSystem,
+      }),
+    });
+    expect(policy.deniedPaths).toContain("/pum");
+    expect(policy.readWritePaths).not.toContain("/pum");
+    expect(policy.readOnlyPaths).not.toContain("/pum");
+  });
+});

--- a/src/session-history-metadata.ts
+++ b/src/session-history-metadata.ts
@@ -41,6 +41,7 @@ export const COMPANION_SUFFIXES = [
   ".tool-groups.json",
   ".goal.json",
   ".todo.json",
+  ".settings.json",
 ] as const;
 
 const DEFAULT_MAX_CACHE_ENTRIES = 256;

--- a/src/session-settings-ui.test.tsx
+++ b/src/session-settings-ui.test.tsx
@@ -1,0 +1,160 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createTestRenderer } from "@opentui/core/testing";
+import { createRoot } from "@opentui/react";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { App } from "./app";
+import { sessionSettingsFileFor } from "./session-settings";
+
+let destroy: (() => void) | undefined;
+const directories: string[] = [];
+afterEach(() => {
+  destroy?.();
+  destroy = undefined;
+  for (const directory of directories.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+const settings = {
+  showThinking: false,
+  theme: "tokyonight" as const,
+  animations: false,
+  workingRuleAnimation: "off" as const,
+  webSearch: false,
+  writingStyle: "none" as const,
+  explanationStrength: "simple" as const,
+  checkMode: "off" as const,
+  checkModel: "mock/check",
+  maxActiveSubagents: 10,
+};
+
+function fakeSession() {
+  const directory = mkdtempSync(join(tmpdir(), "pum-session-settings-ui-"));
+  directories.push(directory);
+  return {
+    agent: {
+      state: {
+        model: { id: "mock-model", provider: "mock", input: ["text"], contextWindow: 32_000 },
+        thinkingLevel: "off",
+      },
+    },
+    sessionManager: { buildContextEntries: () => [], getEntries: () => [] },
+    sessionFile: join(directory, "session.jsonl"),
+    sessionId: "current-session",
+    subscribe: () => () => {},
+    setThinkingLevel() {},
+    setModel: async () => {},
+    clearQueue: () => ({ steering: [], followUp: [] }),
+    abort: async () => {},
+    compact: async () => ({ tokensBefore: 0 }),
+    prompt: async () => {},
+    steer: async () => {},
+  } as any;
+}
+
+async function settle(setup: Awaited<ReturnType<typeof createTestRenderer>>) {
+  await setup.renderOnce();
+  await setup.flush();
+  await new Promise((resolve) => setTimeout(resolve, 40));
+  await setup.renderOnce();
+  await setup.flush();
+}
+
+async function renderApp() {
+  const setup = await createTestRenderer({ width: 100, height: 28, kittyKeyboard: true });
+  destroy = () => setup.renderer.destroy();
+  const session = fakeSession();
+  const manager = {
+    getAgents: () => [],
+    subscribe: () => () => {},
+    bindMainSession: async () => {},
+    abortAgent: async () => {},
+    sendUserMessage: async () => {},
+    persistToolEvent() {},
+    setMaxActiveSubagents() {},
+  } as any;
+  createRoot(setup.renderer).render(
+    <App
+      session={session}
+      modelRuntime={{ getAvailableSnapshot: () => [], getProviders: () => [] } as any}
+      onNewSession={async () => session}
+      loadSessions={async () => []}
+      onSwitchSession={async () => session}
+      settings={settings}
+      searchProviders={[]}
+      subagentManager={manager}
+      promptHistoryStore={{ load: () => [], append: () => [], remove: () => [] }}
+      promptStashStore={{
+        load: () => [],
+        append: () => [],
+        markExecuted: () => [],
+        markExecutedMany: () => [],
+        replace: () => [],
+        remove: () => [],
+      }}
+    />,
+  );
+  await settle(setup);
+  return { setup, session };
+}
+
+/** Open Settings, leave the search box, and land on the first row. */
+async function openSettings(setup: Awaited<ReturnType<typeof createTestRenderer>>) {
+  setup.mockInput.pressKey("p", { ctrl: true });
+  await settle(setup);
+  setup.mockInput.pressArrow("down");
+  await settle(setup);
+}
+
+describe("settings belong to the session", () => {
+  test("a change lands in the session companion file, not the global config", async () => {
+    const { setup, session } = await renderApp();
+    await openSettings(setup);
+
+    setup.mockInput.pressArrow("right");
+    await settle(setup);
+
+    const file = sessionSettingsFileFor(session.sessionFile);
+    expect(existsSync(file)).toBe(true);
+    const stored = JSON.parse(readFileSync(file, "utf8"));
+    // Whatever the first row is, exactly that field moved - and nothing else.
+    expect(Object.keys(stored).length).toBeGreaterThan(0);
+    expect(Object.keys(stored)).not.toContain("checkPaths");
+  });
+
+  test("`s` promotes the session settings and clears the overrides", async () => {
+    const { setup, session } = await renderApp();
+    await openSettings(setup);
+    setup.mockInput.pressArrow("right");
+    await settle(setup);
+    expect(existsSync(sessionSettingsFileFor(session.sessionFile))).toBe(true);
+
+    setup.mockInput.pressKey("s");
+    await settle(setup);
+
+    // Nothing differs from global any more, so the companion file goes.
+    expect(existsSync(sessionSettingsFileFor(session.sessionFile))).toBe(false);
+    setup.mockInput.pressEscape();
+    await settle(setup);
+    expect(setup.captureCharFrame()).toContain("global defaults");
+  });
+
+  test("the footer advertises `s`", async () => {
+    const { setup } = await renderApp();
+    setup.mockInput.pressKey("p", { ctrl: true });
+    await settle(setup);
+    expect(setup.captureCharFrame()).toContain("s save");
+  });
+
+  test("`s` typed into the search box filters instead of saving", async () => {
+    const { setup, session } = await renderApp();
+    setup.mockInput.pressKey("p", { ctrl: true });
+    await settle(setup);
+
+    // The search box owns the keyboard until it is left, so `s` is a character.
+    await setup.mockInput.typeText("s");
+    await settle(setup);
+    expect(existsSync(sessionSettingsFileFor(session.sessionFile))).toBe(false);
+    expect(setup.captureCharFrame()).not.toContain("global defaults");
+  });
+});

--- a/src/session-settings.test.ts
+++ b/src/session-settings.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { normalizeSettings } from "./settings";
+import {
+  loadSessionSettings,
+  mergeSessionSettings,
+  pickSessionSettings,
+  saveSessionSettings,
+  sessionSettingsDiff,
+  sessionSettingsFileFor,
+} from "./session-settings";
+
+const directories: string[] = [];
+afterEach(() => {
+  for (const directory of directories.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+function sessionFile(): string {
+  const directory = mkdtempSync(join(tmpdir(), "pum-session-settings-"));
+  directories.push(directory);
+  return join(directory, "session.jsonl");
+}
+
+const GLOBAL = normalizeSettings({});
+
+describe("the session settings companion file", () => {
+  test("sits beside the session JSONL", () => {
+    const file = join("sessions", "abc.jsonl");
+    expect(sessionSettingsFileFor(file)).toBe(join("sessions", "abc.settings.json"));
+  });
+
+  test("round-trips overrides", () => {
+    const file = sessionFile();
+    saveSessionSettings(file, { theme: "gruvbox", animations: false });
+    expect(loadSessionSettings(file)).toEqual({ theme: "gruvbox", animations: false });
+  });
+
+  test("writes nothing when a session owns no overrides", () => {
+    const file = sessionFile();
+    saveSessionSettings(file, {});
+    expect(existsSync(sessionSettingsFileFor(file))).toBe(false);
+  });
+
+  test("removes the file once the last override goes", () => {
+    const file = sessionFile();
+    saveSessionSettings(file, { theme: "nord" });
+    expect(existsSync(sessionSettingsFileFor(file))).toBe(true);
+    saveSessionSettings(file, {});
+    expect(existsSync(sessionSettingsFileFor(file))).toBe(false);
+  });
+
+  test("a corrupt or missing file reads as no overrides", () => {
+    const file = sessionFile();
+    expect(loadSessionSettings(file)).toEqual({});
+    writeFileSync(sessionSettingsFileFor(file), "{ not json");
+    expect(loadSessionSettings(file)).toEqual({});
+    writeFileSync(sessionSettingsFileFor(file), "[1,2,3]");
+    expect(loadSessionSettings(file)).toEqual({});
+  });
+
+  test("no session file means no overrides and no write", () => {
+    expect(loadSessionSettings(undefined)).toEqual({});
+    expect(() => saveSessionSettings(undefined, { theme: "nord" })).not.toThrow();
+  });
+
+  test("drops fields a session does not own", () => {
+    // A hand-edited file must not become a back door into the app.
+    const picked = pickSessionSettings({ theme: "nord", model: "evil", __proto__: "x" } as any);
+    expect(picked).toEqual({ theme: "nord" });
+  });
+
+  test("the write leaves no temp file behind", () => {
+    const file = sessionFile();
+    saveSessionSettings(file, { theme: "dracula" });
+    const target = sessionSettingsFileFor(file);
+    expect(JSON.parse(readFileSync(target, "utf8"))).toEqual({ theme: "dracula" });
+    expect(readdirSync(dirname(target))).toEqual(["session.settings.json"]);
+  });
+});
+
+describe("merging a session over the global settings", () => {
+  test("overrides win, everything else falls through", () => {
+    const merged = mergeSessionSettings(GLOBAL, { theme: "kanagawa" });
+    expect(merged.theme).toBe("kanagawa");
+    expect(merged.checkMode).toBe(GLOBAL.checkMode);
+  });
+
+  test("a hand-edited override is normalized, not trusted", () => {
+    const merged = mergeSessionSettings(GLOBAL, { maxActiveSubagents: 9999 } as any);
+    expect(merged.maxActiveSubagents).toBeLessThanOrEqual(GLOBAL.maxActiveSubagents * 100);
+    expect(Number.isFinite(merged.maxActiveSubagents)).toBe(true);
+  });
+
+  test("no overrides is the global settings", () => {
+    expect(mergeSessionSettings(GLOBAL, {})).toEqual(GLOBAL);
+  });
+});
+
+describe("what `s` would promote", () => {
+  test("reports only what differs from global", () => {
+    const effective = { ...GLOBAL, theme: "nord", animations: !GLOBAL.animations };
+    expect(sessionSettingsDiff(GLOBAL, effective)).toEqual({
+      theme: "nord",
+      animations: !GLOBAL.animations,
+    });
+  });
+
+  test("an untouched session promotes nothing", () => {
+    expect(sessionSettingsDiff(GLOBAL, { ...GLOBAL })).toEqual({});
+  });
+
+  test("compares nested values structurally, not by identity", () => {
+    const withPaths = { ...GLOBAL, checkPaths: { "/a": ["/b"] } };
+    expect(sessionSettingsDiff(withPaths, { ...GLOBAL, checkPaths: { "/a": ["/b"] } })).toEqual({});
+    expect(sessionSettingsDiff(withPaths, { ...GLOBAL, checkPaths: { "/a": ["/c"] } }))
+      .toEqual({ checkPaths: { "/a": ["/c"] } });
+  });
+});

--- a/src/session-settings.ts
+++ b/src/session-settings.ts
@@ -1,0 +1,119 @@
+import { existsSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+import { normalizeSettings, type PumSettings } from "./settings";
+
+/**
+ * Settings a session overrides for itself.
+ *
+ * The Settings popup writes here, not to the global `pum.json`. Trying a theme
+ * or a Check mode in one session should not change every other session, and it
+ * must never reach into the config directory the sandboxes keep read-only.
+ * `s` in the popup is the one deliberate promotion to global.
+ */
+export type SessionSettings = Partial<PumSettings>;
+
+/** Fields a session may hold. Model and thinking level are pi's, not ours. */
+const OVERRIDABLE = [
+  "showThinking",
+  "theme",
+  "animations",
+  "workingRuleAnimation",
+  "outputMode",
+  "webSearch",
+  "writingStyle",
+  "explanationStrength",
+  "checkMode",
+  "checkModel",
+  "sandboxMode",
+  "checkPaths",
+  "maxActiveSubagents",
+  "goalRetryLimit",
+  "bashOutput",
+] as const;
+
+/** Companion file next to the session JSONL: `<session>.settings.json`. */
+export function sessionSettingsFileFor(sessionFile: string): string {
+  const base = basename(sessionFile).replace(/\.jsonl?$/, "");
+  return join(dirname(sessionFile), `${base}.settings.json`);
+}
+
+/** Keep only the fields a session owns, so an old or hand-edited file cannot smuggle others in. */
+export function pickSessionSettings(value: Record<string, unknown>): SessionSettings {
+  const picked: Record<string, unknown> = {};
+  for (const key of OVERRIDABLE) {
+    if (value[key] !== undefined) picked[key] = value[key];
+  }
+  return picked as SessionSettings;
+}
+
+/**
+ * Read a session's overrides. Never throws: a missing, unreadable or corrupt
+ * file simply means the session runs on the global settings.
+ */
+export function loadSessionSettings(sessionFile: string | undefined): SessionSettings {
+  if (!sessionFile) return {};
+  try {
+    const file = sessionSettingsFileFor(sessionFile);
+    if (!existsSync(file)) return {};
+    const parsed: unknown = JSON.parse(readFileSync(file, "utf8"));
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    return pickSessionSettings(parsed as Record<string, unknown>);
+  } catch {
+    return {};
+  }
+}
+
+/** Persist a session's overrides atomically. A failed write never breaks the session. */
+export function saveSessionSettings(
+  sessionFile: string | undefined,
+  overrides: SessionSettings,
+): void {
+  if (!sessionFile) return;
+  try {
+    const file = sessionSettingsFileFor(sessionFile);
+    const picked = pickSessionSettings(overrides as Record<string, unknown>);
+    if (Object.keys(picked).length === 0) {
+      // An empty overlay is the same as no file, and leaving one behind would
+      // put a stub beside every session ever opened.
+      rmSync(file, { force: true });
+      return;
+    }
+    const temporary = `${file}.${process.pid}.${Date.now()}.tmp`;
+    try {
+      writeFileSync(temporary, JSON.stringify(picked, null, 2), "utf8");
+      renameSync(temporary, file);
+    } catch (error) {
+      rmSync(temporary, { force: true });
+      throw error;
+    }
+  } catch {
+    // Losing an override is survivable; losing the session is not.
+  }
+}
+
+/**
+ * Global settings with a session's overrides laid over them.
+ *
+ * Normalizing afterwards means a hand-edited companion file gets the same
+ * clamping and migration as `pum.json`, rather than a shortcut into the app.
+ */
+export function mergeSessionSettings(
+  global: PumSettings,
+  overrides: SessionSettings,
+): PumSettings {
+  return normalizeSettings({ ...global, ...pickSessionSettings(overrides as Record<string, unknown>) });
+}
+
+/** Fields that differ from global, which is exactly what `s` would promote. */
+export function sessionSettingsDiff(
+  global: PumSettings,
+  effective: PumSettings,
+): SessionSettings {
+  const diff: Record<string, unknown> = {};
+  for (const key of OVERRIDABLE) {
+    const left = (global as Record<string, unknown>)[key];
+    const right = (effective as Record<string, unknown>)[key];
+    if (JSON.stringify(left) !== JSON.stringify(right)) diff[key] = right;
+  }
+  return diff as SessionSettings;
+}

--- a/src/settings-popup.tsx
+++ b/src/settings-popup.tsx
@@ -331,7 +331,7 @@ export function SettingsPopup({
             />
           </box> : null}
           {layout.footerHeight ? <text
-            content={layout.narrow ? "/ search  ↑↓ move  ←→ change  esc back" : "/ search   ↑↓ move   ←→ change   ⏎ open   esc back"}
+            content={layout.narrow ? "/ search  ↑↓ move  ←→ s save  esc back" : "/ search   ↑↓ move   ←→ change   s save global   esc back"}
             fg={theme.dim}
             bg={theme.popupBg}
             wrapMode="none"

--- a/src/subagents/manager.ts
+++ b/src/subagents/manager.ts
@@ -49,6 +49,7 @@ import {
   childAllowedToolNames,
   judgeAllowedToolNames,
 } from "../tool-groups";
+import { TodoToolsController } from "../todo-tools";
 import {
   registerTriggerTools,
   type TriggerRuntimeManager,
@@ -207,6 +208,7 @@ type RuntimeRecord = {
   finishRequested?: string;
   userInstructionNotices?: Map<string, string>;
   toolGroups?: ToolGroupsController;
+  todoTools?: TodoToolsController;
   activityGeneration: number;
   idleNotifiedGeneration: number;
   /**
@@ -1128,6 +1130,9 @@ export class SubagentManager {
         if (toolGroupsRecord?.toolGroups) {
           toolGroupsRecord.toolGroups.registerTool(pi);
         }
+        if (toolGroupsRecord?.todoTools) {
+          toolGroupsRecord.todoTools.registerTool(pi);
+        }
         if (this.triggerManager) {
           registerTriggerTools(
             pi,
@@ -1789,6 +1794,10 @@ export class SubagentManager {
     if (!judge) {
       record.toolGroups = new ToolGroupsController("subagent", undefined, record.snapshot.readonly);
       record.toolGroups.load(sessionManager.getSessionFile());
+      // Each child owns its own list. Binding it to the child's session file is
+      // what keeps one agent out of another's plan.
+      record.todoTools = new TodoToolsController("subagent");
+      record.todoTools.load(sessionManager.getSessionFile());
     }
     const services = await createAgentSessionServices({
       cwd: record.snapshot.worktree.path,

--- a/src/subagents/manager.ts
+++ b/src/subagents/manager.ts
@@ -47,8 +47,11 @@ import {
 import {
   ToolGroupsController,
   childAllowedToolNames,
+  afkAllowedToolNames,
   judgeAllowedToolNames,
 } from "../tool-groups";
+import { isInternalRole } from "./types";
+import { AFK_ANSWER_TOOL_NAME, afkAnswerParameters } from "../afk-delegate";
 import { TodoToolsController } from "../todo-tools";
 import {
   registerTriggerTools,
@@ -80,6 +83,7 @@ import {
   AGENT_MESSAGE_CUSTOM_TYPE,
   AGENT_MESSAGE_DISPLAY_TYPE,
   SUBAGENT_CUSTOM_TYPE,
+  AGENT_NOTICE_CUSTOM_TYPE,
   TOOL_EVENT_CUSTOM_TYPE,
   TRIGGER_EVENT_CUSTOM_TYPE,
   type AgentMessageData,
@@ -171,7 +175,7 @@ export function countActiveSubagents(
 ): number {
   let count = 0;
   for (const agent of agents) {
-    if (agent.role === "judge") continue;
+    if (isInternalRole(agent.role)) continue;
     if (ACTIVE_SUBAGENT_STATUSES.has(agent.status)) count += 1;
   }
   return count;
@@ -233,6 +237,7 @@ type RuntimeRecord = {
   spawnParameters?: ReturnType<typeof spawnSubagentParameters>;
   /** Set only for a goal judge: where its single structured verdict is delivered. */
   goalVerdict?: (raw: unknown) => void;
+  afkAnswer?: (raw: unknown) => void;
 };
 
 type IdleOpenReminderState = {
@@ -482,7 +487,7 @@ export class SubagentManager {
     for (const restoredSnapshot of restored.values()) {
       // A judge belongs to one review of one live session. Resuming one would
       // retain a record that no verdict can ever close, so drop it here.
-      if (restoredSnapshot.role === "judge") {
+      if (isInternalRole(restoredSnapshot.role)) {
         this.persist({ event: "removed", id: restoredSnapshot.id, at: Date.now() });
         continue;
       }
@@ -598,6 +603,24 @@ export class SubagentManager {
     this.emit();
   }
 
+  /**
+   * Show one line in a child's transcript and keep it across resume.
+   *
+   * The custom entry is display-only: it is replayed for the user and never
+   * re-enters the model's context, because whatever produced it already told
+   * the agent through its own tool result.
+   */
+  appendAgentLine(agentId: string, line: Line): void {
+    const record = this.records.get(agentId);
+    if (!record) return;
+    this.appendLine(record, line);
+    try {
+      record.session?.sessionManager.appendCustomEntry(AGENT_NOTICE_CUSTOM_TYPE, { agentId, line });
+    } catch {
+      // The row is already on screen; failing to persist it must not throw here.
+    }
+  }
+
   private updateTranscript(record: RuntimeRecord, update: (value: AgentTranscript) => AgentTranscript): void {
     record.snapshot.transcript = update(record.snapshot.transcript);
     record.snapshot.updatedAt = Date.now();
@@ -683,7 +706,7 @@ export class SubagentManager {
     const subagents = (agentId === null
       ? [...this.records.values()]
       : this.retainedDescendants(agentId).map(({ record }) => record)
-    ).filter((record) => record.snapshot.role !== "judge");
+    ).filter((record) => !isInternalRole(record.snapshot.role));
     const targetSessionId = agentId === null ? undefined : this.records.get(agentId)?.session?.sessionId;
     const triggers = (this.triggerManager?.getTriggers?.() ?? []).filter((trigger) =>
       !CLOSED_TRIGGER_STATES.has(trigger.state)
@@ -1061,6 +1084,14 @@ export class SubagentManager {
         pi.on("before_agent_start", (event) => {
           const record = this.records.get(agentId);
           if (!record) return;
+          if (record.snapshot.role === "afk") {
+            return {
+              systemPrompt: `${event.systemPrompt}\n\nYou are the PUM AFK delegate (${agentId}). `
+                + "You answer one questionnaire on the user's behalf while they are away. "
+                + "You have no files, no shell and no network - the answer tool is all you have. "
+                + `Answer every question once with ${AFK_ANSWER_TOOL_NAME} and stop.`,
+            };
+          }
           if (record.snapshot.role === "judge") {
             return {
               systemPrompt: `${event.systemPrompt}\n\nYou are the PUM goal judge (${agentId}). `
@@ -1106,6 +1137,29 @@ export class SubagentManager {
               record.goalVerdict = undefined;
               deliver(params);
               return { ...textResult("Verdict recorded."), terminate: true };
+            },
+          });
+          return;
+        }
+
+        // The delegate owns one tool. It must not get the questionnaire tool in
+        // particular: the queue is global and single-file, so a delegate that
+        // could raise its own questionnaire would wait behind itself forever.
+        if (this.records.get(agentId)?.snapshot.role === "afk") {
+          pi.registerTool({
+            name: AFK_ANSWER_TOOL_NAME,
+            label: "AFK Answer",
+            description: "Answer every question in the current questionnaire, then stop.",
+            promptSnippet: "Answer the questionnaire once",
+            parameters: afkAnswerParameters,
+            execute: async (_id, params) => {
+              const record = this.records.get(agentId);
+              if (!record?.afkAnswer) throw new Error("This questionnaire is no longer live.");
+              // One answer per delegate. A second call must not start another turn.
+              const deliver = record.afkAnswer;
+              record.afkAnswer = undefined;
+              deliver(params);
+              return { ...textResult("Answer recorded."), terminate: true };
             },
           });
           return;
@@ -1637,9 +1691,45 @@ export class SubagentManager {
 
   /** Stop and forget a judge. It owns no worktree, so nothing is merged or removed. */
   async removeGoalJudge(id: string): Promise<void> {
+    await this.removeInternalAgent(id, "judge");
+  }
+
+  /**
+   * One restricted agent that answers a single questionnaire for AFK mode.
+   *
+   * It gets no filesystem, no bash and no network: the answer tool is its whole
+   * world. That is why `readonly` stays false - the allowlist already denies
+   * everything readonly would, and readonly would demand an OS sandbox PUM does
+   * not need here.
+   */
+  async spawnAfkDelegate(options: {
+    task: string;
+    modelId: string;
+    thinkingLevel: string;
+    onAnswer: (raw: unknown) => void;
+  }): Promise<SubagentSnapshot> {
+    return this.spawn({
+      task: options.task,
+      modelId: options.modelId,
+      thinkingLevel: options.thinkingLevel,
+      readonly: false,
+      createWorktree: false,
+      role: "afk",
+      parentAgentId: null,
+      onAfkAnswer: options.onAnswer,
+    });
+  }
+
+  /** Stop and forget an AFK delegate. Like a judge, it owns nothing to clean up. */
+  async removeAfkDelegate(id: string): Promise<void> {
+    await this.removeInternalAgent(id, "afk");
+  }
+
+  private async removeInternalAgent(id: string, role: SubagentRole): Promise<void> {
     const record = this.records.get(id);
-    if (!record || record.snapshot.role !== "judge") return;
+    if (!record || record.snapshot.role !== role) return;
     record.goalVerdict = undefined;
+    record.afkAnswer = undefined;
     await this.stop(id, "stopped", false);
     this.statsManager?.closeAgent(id);
     this.records.delete(id);
@@ -1658,7 +1748,7 @@ export class SubagentManager {
     let allocatedSessionFile: string | undefined;
     const record = await this.withWorktreeLock(async () => {
       // The judge is not a worker, so the parallel-work limit does not apply.
-      if (options.role !== "judge" && this.activeCount() >= this.maxActiveSubagents) {
+      if (!isInternalRole(options.role) && this.activeCount() >= this.maxActiveSubagents) {
         throw activeLimitError(this.maxActiveSubagents);
       }
       if (this.records.size >= MAX_RETAINED_AGENTS) throw new Error(`At most ${MAX_RETAINED_AGENTS} subagents can be retained`);
@@ -1669,12 +1759,13 @@ export class SubagentManager {
       }
 
       const id = randomUUID().slice(0, 8);
-      // A judge inspects the launch project itself, so it gets no worktree and
-      // no branch. Nothing has to be merged or removed when it is cleaned up.
+      // An internal agent works against the launch project itself, so it gets
+      // no worktree and no branch. Nothing has to be merged or removed when it
+      // is cleaned up.
       const managed = options.createWorktree !== false;
       const worktree = managed
         ? await createWorktree(this.mainCwd, options.name)
-        : this.projectWorktreeRecord(options.name ?? `judge-${id}`);
+        : this.projectWorktreeRecord(options.name ?? `${options.role ?? "internal"}-${id}`);
       try {
         const now = Date.now();
         const snapshot: SubagentSnapshot = {
@@ -1709,6 +1800,7 @@ export class SubagentManager {
           activityGeneration: 0,
           idleNotifiedGeneration: 0,
           goalVerdict: options.onGoalVerdict,
+        afkAnswer: options.onAfkAnswer,
         };
         this.records.set(id, created);
         // Register the agent before runtime setup can fail. A fresh spawn that
@@ -1790,8 +1882,9 @@ export class SubagentManager {
       : SessionManagerClass.create(record.snapshot.worktree.path, sessionDir);
     // Each child tracks its own enabled tool groups, persisted next to its
     // session file. Restore before the child's enable_tools tool registers.
+    const internal = isInternalRole(record.snapshot.role);
     const judge = record.snapshot.role === "judge";
-    if (!judge) {
+    if (!internal) {
       record.toolGroups = new ToolGroupsController("subagent", undefined, record.snapshot.readonly);
       record.toolGroups.load(sessionManager.getSessionFile());
       // Each child owns its own list. Binding it to the child's session file is
@@ -1820,7 +1913,9 @@ export class SubagentManager {
       sessionManager,
       model,
       thinkingLevel: record.snapshot.thinkingLevel as any,
-      tools: judge ? judgeAllowedToolNames() : childAllowedToolNames(record.snapshot.readonly),
+      tools: record.snapshot.role === "afk"
+        ? afkAllowedToolNames()
+        : judge ? judgeAllowedToolNames() : childAllowedToolNames(record.snapshot.readonly),
     });
     record.session = result.session;
     record.snapshot.sessionFile = result.session.sessionFile;
@@ -2505,7 +2600,7 @@ export class SubagentManager {
   ): Promise<void> {
     // A judge reports through goal_verdict only. It never sends a lifecycle
     // notice, so it can neither create a News item nor start an ack loop.
-    if (record.snapshot.role === "judge") return;
+    if (isInternalRole(record.snapshot.role)) return;
     const id = this.settlementId(record, status);
     let settlement = this.settlements.get(id);
     if (!settlement) {
@@ -2797,8 +2892,8 @@ export class SubagentManager {
     if (action === "merge") {
       return this.withWorktreeLock(async () => {
         const managedAgent = this.findRecord(target);
-        if (managedAgent?.snapshot.role === "judge") {
-          throw new Error("A goal judge holds no worktree and nothing to merge.");
+        if (isInternalRole(managedAgent?.snapshot.role)) {
+          throw new Error(`A ${managedAgent!.snapshot.role} agent holds no worktree and nothing to merge.`);
         }
         if (managedAgent) {
           this.assertNoRetainedDescendants(managedAgent, "merge");
@@ -2831,8 +2926,10 @@ export class SubagentManager {
     if (action === "remove") {
       return this.withWorktreeLock(async () => {
         const managedAgent = this.findRecord(target);
-        if (managedAgent?.snapshot.role === "judge") {
-          throw new Error("A goal judge holds no worktree and is closed by the goal lifecycle.");
+        if (isInternalRole(managedAgent?.snapshot.role)) {
+          throw new Error(
+            `A ${managedAgent!.snapshot.role} agent holds no worktree; PUM closes it itself.`,
+          );
         }
         if (managedAgent && ["starting", "running"].includes(managedAgent.snapshot.status)) {
           throw new Error(`Stop ${managedAgent.snapshot.name} before ${action}`);

--- a/src/subagents/readonly.ts
+++ b/src/subagents/readonly.ts
@@ -1,5 +1,6 @@
 import type { InlineExtension } from "@earendil-works/pi-coding-agent";
 import { rejectedToolDetails } from "../check-mode";
+import { TODO_TOOL_NAMES } from "../todo-tools";
 
 const SAFE_TOOLS = new Set([
   "read",
@@ -17,6 +18,9 @@ const SAFE_TOOLS = new Set([
   "cancel_trigger",
   "web_search",
   "goal_verdict",
+  // Todo tools touch one companion file the child already owns. Listing a task
+  // is not a project mutation, so a readonly child keeps its own plan.
+  ...TODO_TOOL_NAMES,
 ]);
 
 export function readonlyToolBlockReason(

--- a/src/subagents/types.ts
+++ b/src/subagents/types.ts
@@ -12,12 +12,23 @@ export const SUBAGENT_CUSTOM_TYPE = "pum.subagent";
 export const AGENT_MESSAGE_CUSTOM_TYPE = "pum.agent_message";
 export const AGENT_MESSAGE_DISPLAY_TYPE = "pum.agent_message_display";
 export const TOOL_EVENT_CUSTOM_TYPE = "pum.tool_event";
+/** A display-only notice PUM wrote into an agent's transcript, replayed on resume. */
+export const AGENT_NOTICE_CUSTOM_TYPE = "pum.agent_notice";
 export const TRIGGER_EVENT_CUSTOM_TYPE = EXTERNAL_TRIGGER_CUSTOM_TYPE;
 /** Hidden user-message prefix used only to guarantee that the main loop wakes. */
 export const SUBAGENT_WAKE_PREFIX = "[PUM internal subagent wake]";
 
 /** A plain worker, or the goal judge that reviews after a settled turn. */
-export type SubagentRole = "worker" | "judge";
+export type SubagentRole = "worker" | "judge" | "afk";
+
+/**
+ * Roles PUM drives for itself. They never join the managed tree, never count
+ * toward capacity, and never own a worktree, so every place that walks the
+ * user's agents has to skip them.
+ */
+export function isInternalRole(role: SubagentRole | undefined): boolean {
+  return role === "judge" || role === "afk";
+}
 
 export type SubagentStatus =
   | "starting"
@@ -151,6 +162,8 @@ export type SpawnSubagentOptions = {
   forkSource?: ForkSource;
   /** Runtime-only judge sink. Set before the first turn so no verdict can race it. */
   onGoalVerdict?: (raw: unknown) => void;
+  /** Receives the delegate's single AFK answer. Set before the first turn. */
+  onAfkAnswer?: (raw: unknown) => void;
 };
 
 export type RoutedPrompt = {

--- a/src/todo-ui.test.tsx
+++ b/src/todo-ui.test.tsx
@@ -1,0 +1,191 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createTestRenderer } from "@opentui/core/testing";
+import { createRoot } from "@opentui/react";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { App } from "./app";
+import { saveTodoTasks, type TodoTask } from "./todo";
+
+let destroy: (() => void) | undefined;
+afterEach(() => {
+  destroy?.();
+  destroy = undefined;
+});
+
+const settings = {
+  showThinking: false,
+  theme: "tokyonight" as const,
+  animations: false,
+  workingRuleAnimation: "off" as const,
+  webSearch: false,
+  writingStyle: "none" as const,
+  explanationStrength: "simple" as const,
+  checkMode: "off" as const,
+  checkModel: "mock/check",
+  maxActiveSubagents: 10,
+};
+
+const T0 = 1_700_000_000_000;
+
+function task(id: string, text: string, status: TodoTask["status"], age = 0): TodoTask {
+  return { id, text, status, createdAt: T0 + age, updatedAt: T0 + age };
+}
+
+function fakeSession(path: string) {
+  return {
+    agent: {
+      state: {
+        model: { id: "mock-model", provider: "mock", input: ["text"], contextWindow: 32_000 },
+        thinkingLevel: "off",
+      },
+    },
+    sessionManager: { buildContextEntries: () => [], getEntries: () => [] },
+    sessionFile: path,
+    sessionId: "current-session",
+    subscribe: () => () => {},
+    setThinkingLevel() {},
+    setModel: async () => {},
+    clearQueue: () => ({ steering: [], followUp: [] }),
+    abort: async () => {},
+    compact: async () => ({ tokensBefore: 0 }),
+    prompt: async () => {},
+    steer: async () => {},
+  } as any;
+}
+
+async function settle(setup: Awaited<ReturnType<typeof createTestRenderer>>) {
+  await setup.renderOnce();
+  await setup.flush();
+  await new Promise((resolve) => setTimeout(resolve, 40));
+  await setup.renderOnce();
+  await setup.flush();
+}
+
+async function renderApp(tasks: TodoTask[] = [], width = 100, height = 28) {
+  const sessionFile = join(mkdtempSync(join(tmpdir(), "pum-todo-ui-")), "current-session.jsonl");
+  if (tasks.length > 0) saveTodoTasks(sessionFile, tasks);
+  const session = fakeSession(sessionFile);
+  const setup = await createTestRenderer({ width, height, kittyKeyboard: true });
+  destroy = () => setup.renderer.destroy();
+  const manager = {
+    getAgents: () => [],
+    subscribe: () => () => {},
+    bindMainSession: async () => {},
+    abortAgent: async () => {},
+    sendUserMessage: async () => {},
+    persistToolEvent() {},
+  } as any;
+  createRoot(setup.renderer).render(
+    <App
+      session={session}
+      modelRuntime={{ getAvailableSnapshot: () => [], getProviders: () => [] } as any}
+      onNewSession={async () => session}
+      loadSessions={async () => []}
+      onSwitchSession={async () => session}
+      settings={settings}
+      searchProviders={[]}
+      subagentManager={manager}
+      promptHistoryStore={{ load: () => [], append: () => [], remove: () => [] }}
+      promptStashStore={{
+        load: () => [],
+        append: () => [],
+        markExecuted: () => [],
+        markExecutedMany: () => [],
+        replace: () => [],
+        remove: () => [],
+      }}
+    />,
+  );
+  await settle(setup);
+  return setup;
+}
+
+describe("todo popup in the app", () => {
+  test("Ctrl+O opens the list and Esc gives the prompt back", async () => {
+    const setup = await renderApp([
+      task("aaa111", "write the parser", "active"),
+      task("bbb222", "review the diff", "pending", 1),
+    ]);
+
+    setup.mockInput.pressKey("o", { ctrl: true });
+    await settle(setup);
+    let frame = setup.captureCharFrame();
+    expect(frame).toContain("write the parser");
+    expect(frame).toContain("review the diff");
+    expect(frame).toContain("esc close");
+
+    setup.mockInput.pressEscape();
+    await settle(setup);
+    frame = setup.captureCharFrame();
+    expect(frame).not.toContain("write the parser");
+
+    // Focus must come back, or the prompt silently swallows everything typed next.
+    await setup.mockInput.typeText("after close");
+    await settle(setup);
+    expect(setup.captureCharFrame()).toContain("after close");
+  });
+
+  test("Ctrl+O does not type a control character into the prompt", async () => {
+    const setup = await renderApp();
+    setup.mockInput.pressKey("o", { ctrl: true });
+    await settle(setup);
+    setup.mockInput.pressEscape();
+    await settle(setup);
+    await setup.mockInput.typeText("plain");
+    await settle(setup);
+    const promptRow = setup.captureCharFrame().split("\n").findLast((row) => row.includes("❯"));
+    expect(promptRow).toContain("plain");
+    expect(promptRow).not.toContain("");
+  });
+
+  test("/todo opens the same popup and clears the command text", async () => {
+    const setup = await renderApp([task("ccc333", "ship the release", "blocked")]);
+    await setup.mockInput.typeText("/todo");
+    setup.mockInput.pressEnter();
+    await settle(setup);
+
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("ship the release");
+    expect(frame).not.toContain("❯ /todo");
+  });
+
+  test("an empty list explains how the agent turns the tools on", async () => {
+    const setup = await renderApp();
+    setup.mockInput.pressKey("o", { ctrl: true });
+    await settle(setup);
+
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("enable_tools");
+    expect(frame).toContain("Todo");
+    expect(frame).toContain("todo_add");
+  });
+
+  test("f cycles the filter and the footer reports it", async () => {
+    const setup = await renderApp([
+      task("aaa111", "an active one", "active"),
+      task("bbb222", "a completed one", "completed", 1),
+    ]);
+    setup.mockInput.pressKey("o", { ctrl: true });
+    await settle(setup);
+    expect(setup.captureCharFrame()).toContain("filter all");
+
+    setup.mockInput.pressKey("f");
+    await settle(setup);
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("filter active");
+    expect(frame).toContain("an active one");
+    expect(frame).not.toContain("a completed one");
+  });
+
+  test("the popup opens on a narrow, short terminal without losing the footer", async () => {
+    const setup = await renderApp([task("aaa111", "still reachable", "pending")], 52, 14);
+    setup.mockInput.pressKey("o", { ctrl: true });
+    await settle(setup);
+
+    const rows = setup.captureCharFrame().split("\n");
+    expect(rows.some((row) => row.includes("still reachable"))).toBe(true);
+    expect(rows.some((row) => row.includes("esc"))).toBe(true);
+    for (const row of rows) expect(Array.from(row).length).toBeLessThanOrEqual(52);
+  });
+});

--- a/src/tool-groups.ts
+++ b/src/tool-groups.ts
@@ -3,6 +3,7 @@ import { basename, dirname, join } from "node:path";
 import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { Type } from "typebox";
 import { GOAL_VERDICT_TOOL_NAME } from "./goal-judge";
+import { TODO_TOOL_NAMES } from "./todo-tools";
 
 /**
  * Always-present tool that reveals hidden tool groups in this thread.
@@ -104,7 +105,7 @@ export const SHELLS_GROUP_TOOL_NAMES = [
  * The hidden groups. There is no News group because PUM has no news model
  * tool (news.ts is a UI-only feature), so that group would contain zero tools.
  */
-export const TOOL_GROUP_NAMES = ["Admin", "Subagents", "Worktree", "Shells"] as const;
+export const TOOL_GROUP_NAMES = ["Admin", "Subagents", "Worktree", "Shells", "Todo"] as const;
 
 export type ToolGroupName = (typeof TOOL_GROUP_NAMES)[number];
 
@@ -121,6 +122,7 @@ export const TOOL_GROUPS: Readonly<Record<ToolGroupName, ToolGroupDefinition>> =
   Subagents: { label: "Subagents", toolNames: SUBAGENTS_GROUP_TOOL_NAMES },
   Worktree: { label: "Worktree", toolNames: WORKTREE_GROUP_TOOL_NAMES },
   Shells: { label: "Shells", toolNames: SHELLS_GROUP_TOOL_NAMES },
+  Todo: { label: "Todo", toolNames: TODO_TOOL_NAMES },
 };
 
 /** Union of every optional tool name across all hidden groups. */
@@ -129,6 +131,7 @@ export const ALL_GROUP_TOOL_NAMES: readonly string[] = [
   ...SUBAGENTS_GROUP_TOOL_NAMES,
   ...WORKTREE_GROUP_TOOL_NAMES,
   ...SHELLS_GROUP_TOOL_NAMES,
+  ...TODO_TOOL_NAMES,
 ];
 
 /** The tool names a session of an audience may expose (the allowlist). */

--- a/src/tool-groups.ts
+++ b/src/tool-groups.ts
@@ -4,6 +4,7 @@ import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { Type } from "typebox";
 import { GOAL_VERDICT_TOOL_NAME } from "./goal-judge";
 import { TODO_TOOL_NAMES } from "./todo-tools";
+import { AFK_ANSWER_TOOL_NAME } from "./afk-delegate";
 
 /**
  * Always-present tool that reveals hidden tool groups in this thread.
@@ -140,6 +141,13 @@ export function mainAllowedToolNames(): string[] {
 }
 
 /** The complete tool list of a goal judge session. */
+/** An AFK delegate holds one tool. No files, no shell, no network, no delegation. */
+export const AFK_TOOL_NAMES = [AFK_ANSWER_TOOL_NAME] as const;
+
+export function afkAllowedToolNames(): string[] {
+  return [...AFK_TOOL_NAMES];
+}
+
 export function judgeAllowedToolNames(): string[] {
   return [...JUDGE_TOOL_NAMES];
 }

--- a/src/tool-line.ts
+++ b/src/tool-line.ts
@@ -156,6 +156,12 @@ export function toolArg(name: string, args: any, cwd: string): string {
     if (typeof args.id === "string") return `${action} · ${args.id}`;
     return action;
   }
+  if (name.startsWith("todo_")) {
+    // The id alone is opaque, so pair it with the text when the call carries one.
+    const parts = [args?.id, args?.text, args?.status]
+      .filter((part): part is string => typeof part === "string" && part.length > 0);
+    return parts.join(" · ").split("\n")[0] ?? "";
+  }
   if (name === "enable_tools" && Array.isArray(args.groups)) {
     return args.groups.filter((group: unknown): group is string => typeof group === "string").join(", ");
   }


### PR DESCRIPTION
The serial half of the batch: the leaf modules from #16-#26 wired into `app.tsx`, `commands.ts`, `tool-groups.ts` and `subagents/`, plus the settings change requested afterwards.

## Todo (#12)
Five tools behind a hidden `Todo` group, registered for the main session and for each managed child, each bound to its own session file — that binding is what keeps one agent out of another's plan. Readonly children keep the tools, since a task list is not a project mutation. `Ctrl+O` and `/todo` open the view-only popup for the selected transcript.

The popup's visibility is **derived** rather than force-closed from each opener. Thirteen sites already force-close News; adding a line to each is how the next popup ends up showing two at once.

## /afk (#14)
Intercepted above the child-transcript routing, because it belongs to the process rather than any one transcript — and because anything past that point writes the instructions into prompt history, which the spec forbids.

Each questionnaire gets one fresh delegate holding a single tool. It is denied the questionnaire tool in particular: the queue is global and single-file, so a delegate that could raise its own would wait behind itself forever. Every failure surrenders to the user rather than retrying, leaving the original request untouched so its popup reappears.

Judge and delegate now share one `isInternalRole` test instead of eleven `role === "judge"` checks.

## pum worktree (#13, CLI half)
Dispatch for #15. The worktree is created before `main` is imported, because `main.tsx` reads `process.cwd()` as it mounts. The source repository arrives on a new `LaunchContext` rather than `StartupOptions` — it is a fact about the process, not a parsed argument — and joins the outer-sandbox roots so `/check-path` never learns it.

## Settings
Changing a setting no longer rewrites the global `pum.json`. It applies to the current session and persists beside it as `<session>.settings.json`, holding only the fields that differ from global. `s` in the Settings popup promotes them.

With that in place no agent needs to write the config directory, so the main agent's exact-file allowance for `settings.json`, `pum.json` and `theme.json` is revoked.

**Not done, and worth a decision:** the outer sandbox still mounts `PUM_DIR` `:rw`. `outer-sandbox.ts:98` rejects any mount that is not a directory, and that directory mixes config with `sessions/`, `subagents/`, `history.json` and `prompt-stash.json`. Enforcing read-only config there needs a layout split, not a mount change.

## Also
- An absolute path no longer matches a slash command, so Tab on `/u` completes `/usr/lib` instead of turning it into `/new`. Fixed in `matchingCommands`, which covers Enter and the arrows too.
- `.settings.json` added to the companion sweep.

## Verification
`bun test`: 1347 pass, 1 skip, 0 fail. `tsc` clean. Verified in tmux: the popup renders with its glyphs, ids and footer; `f` cycles the filter; the AFK label shares one 100-column rule row with the prompt directly beneath it.