### PR TITLE
Make the AFK audit row survive a resume

### DIFF
--- a/src/afk-ui.test.tsx
+++ b/src/afk-ui.test.tsx
@@ -26,6 +26,8 @@ const settings = {
   maxActiveSubagents: 10,
 };
 
+const customEntries: { type: string; data: any }[] = [];
+
 function fakeSession() {
   const path = join(mkdtempSync(join(tmpdir(), "pum-afk-ui-")), "current-session.jsonl");
   return {
@@ -35,7 +37,11 @@ function fakeSession() {
         thinkingLevel: "off",
       },
     },
-    sessionManager: { buildContextEntries: () => [], getEntries: () => [] },
+    sessionManager: {
+      buildContextEntries: () => [],
+      getEntries: () => [],
+      appendCustomEntry: (type: string, data: any) => { customEntries.push({ type, data }); },
+    },
     sessionFile: path,
     sessionId: "current-session",
     subscribe: () => () => {},
@@ -172,6 +178,29 @@ describe("/afk in the app", () => {
       answers: [{ questionId: "q1", value: "redis", label: "Redis", custom: false }],
     });
     expect(setup.captureCharFrame()).toContain("AFK answered for main");
+  });
+
+  test("the audit row is persisted, so resume can replay it", async () => {
+    customEntries.length = 0;
+    const questionnaireManager = new QuestionnaireManager();
+    const { setup, spawned } = await renderApp(questionnaireManager);
+    await type(setup, "/afk");
+    void questionnaireManager.request({ id: "main", name: "main" }, QUESTIONS);
+    await settle(setup);
+
+    spawned[0]!.onAnswer({
+      requestId: questionnaireManager.current()!.id,
+      generation: "1",
+      answers: [{ questionId: "q1", value: "redis", label: "Redis", custom: false }],
+    });
+    await settle(setup);
+
+    // Drawing the row is not enough: appendMainLine is UI-only, so without a
+    // custom entry the row is gone the moment the session is resumed.
+    const notices = customEntries.filter((entry) => entry.type === "pum.agent_notice");
+    expect(notices).toHaveLength(1);
+    expect(notices[0]!.data.line.text).toContain("AFK answered for main");
+    expect(notices[0]!.data.line.text).toContain("Redis");
   });
 
   test("the prompt stays usable while a delegate answers", async () => {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -82,6 +82,7 @@ import {
 import { matchingCommands, moveCommandSelection } from "./commands";
 import { truncateStatusText } from "./status-metadata";
 import { modeLineLabels } from "./mode-line";
+import { AGENT_NOTICE_CUSTOM_TYPE } from "./subagents/types";
 import {
   loadSessionSettings,
   mergeSessionSettings,
@@ -1501,11 +1502,13 @@ export function App({
   );
 
   useEffect(() => {
+    // A delegate answering counts as work even though it is not a managed
+    // agent, or the terminal reads as idle while AFK decides something.
     terminalTitle?.update({
-      working: busy || activeSubagentCount > 0,
+      working: busy || activeSubagentCount > 0 || afkAnswering,
       activeSubagentCount,
     });
-  }, [terminalTitle, busy, activeSubagentCount]);
+  }, [terminalTitle, busy, activeSubagentCount, afkAnswering]);
 
   useEffect(() => spawnPreviewManager?.subscribe(() => {
     setSpawnPreviewRevision((revision) => revision + 1);
@@ -2132,8 +2135,18 @@ export function App({
       role: "system" as const,
       text: [`AFK answered for ${request.requester.name}`, ...lines].join("\n"),
     };
-    if (request.requester.id === "main") appendMainLine(row);
-    else subagentManager.appendAgentLine(request.requester.id, row);
+    if (request.requester.id === "main") {
+      appendMainLine(row);
+      // appendMainLine only draws. Persist it too, or the row is gone on resume.
+      try {
+        session.sessionManager.appendCustomEntry?.(AGENT_NOTICE_CUSTOM_TYPE, {
+          agentId: "main",
+          line: row,
+        });
+      } catch {
+        // The row is already on screen; failing to persist must not throw here.
+      }
+    } else subagentManager.appendAgentLine(request.requester.id, row);
   };
 
   const afkDelegateRef = useRef<{


### PR DESCRIPTION
Two acceptance criteria from #14 that did not actually hold when I checked them against the code.

- **"Each automatic answer creates a replayable audit row in the requester transcript."** The child path persisted a `pum.agent_notice` custom entry, but the main path called `appendMainLine`, which only draws. A main-agent audit row was gone on resume. Now persisted through the same custom entry the replay decoder already understands, with a test that asserts the entry rather than the pixels.
- **"Treat the terminal as working while the delegate is active."** The terminal title is driven by `busy || activeSubagentCount > 0`, and `countActiveSubagents` deliberately skips internal roles — so the terminal read as idle while AFK was deciding something.