### PR TITLE
Settle Windows on one spelling of a path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -702,6 +702,20 @@ Each of these cost real debugging. They are not obvious from the docs.
   roots and mutation targets must use the shared canonical identity and
   containment helpers in `platform.ts`; raw string or `realpath()` spelling
   comparisons can reject valid roots or authorize the wrong boundary.
+- **`realpathSync` and `realpath` disagree about 8.3 names.** The sync one
+  leaves a short name as it found it; the async one expands it. A root
+  registered through one then never matches a path resolved through the other,
+  and only Windows sees it, because only Windows has short names. Go through
+  `canonicalRealpathSync` / `canonicalRealpath` in `platform.ts`, which ask the
+  OS. This hid two real bugs: staged pasted text and captured bash output were
+  handed to the agent under a spelling PUM's own sandbox refused.
+- **Windows strips a trailing space from a path component.** `repo dir ` is
+  created as `repo dir`, so a case built on one cannot be reproduced there.
+- **A contended exclusive create is `EPERM` on Windows, not `EEXIST`** - the
+  same code a filesystem uses to say it cannot lock at all. Telling the two
+  apart by whether the lock file exists is not enough on its own: a holder
+  releasing between the failed create and the check looks identical. Only a
+  failure that repeats means locking is unavailable.
 - **Bubblewrap mount order is part of the security policy.** Add system and
   read-only mounts first, writable project roots next, and private temporary and
   denied-path masks last. Reordering these arguments can expose credentials

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to PUM are documented in this file.
 - An absolute path no longer matches a slash command, so Tab on `/u` completes `/usr/lib` instead of turning it into `/new`.
 
 ### Fixed
+- Staged pasted text and captured bash output are reachable on Windows accounts with an 8.3 short name. PUM stored the path `mkdtemp` returned rather than the canonical one the sandbox registered, so it handed the agent a path its own sandbox then refused.
+- The prompt cache no longer loses an entry when two PUM processes write at once. The cross-process lock gave up after two seconds of contention and carried on unlocked, and read a contended exclusive create on Windows as "this filesystem cannot lock".
+- A repository whose directory name ends in a space resolves. The trailing space was trimmed off the path git reported, leaving a path that does not exist.
 - Orphaned `.goal.json` files are swept when a session is deleted. The sweep never knew about them, so one was left behind for every session removed since goals shipped.
 
 - Added an autonomous goal mode. `/goal <text>` stores a goal with the session and starts work at once; `/goalf <draft>` interviews you first and stores nothing until you confirm the one goal it proposes. `/goal stop`, `/goal continue`, `/goal status`, and `/goal clear` control it, and replacing or clearing a goal asks first.

--- a/src/bash-output.test.ts
+++ b/src/bash-output.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { canonicalRealpathSync } from "./platform";
 import {
   DEFAULT_BASH_OUTPUT,
   cleanupBashOutputCaptures,
@@ -218,8 +219,8 @@ describe("summarizeBashOutput", () => {
 
 describe("bash output capture and the filesystem sandbox", () => {
   test("the agent can read a capture path, but not an unrelated temp path", async () => {
-    const project = mkdtempSync(join(tmpdir(), "pum-bash-sandbox-project-"));
-    const unrelated = mkdtempSync(join(tmpdir(), "pum-bash-sandbox-unrelated-"));
+    const project = canonicalRealpathSync(mkdtempSync(join(tmpdir(), "pum-bash-sandbox-project-")));
+    const unrelated = canonicalRealpathSync(mkdtempSync(join(tmpdir(), "pum-bash-sandbox-unrelated-")));
     const capture = await createBashOutputCapture({
       exec: async (_command, _cwd, options) => {
         options.onData(Buffer.from("captured\n"));
@@ -244,7 +245,7 @@ describe("bash output capture and the filesystem sandbox", () => {
 
 describe("cleanupBashOutputCaptures", () => {
   test("removes the capture directory, withdraws the read root, and repeats safely", async () => {
-    const project = mkdtempSync(join(tmpdir(), "pum-bash-cleanup-project-"));
+    const project = canonicalRealpathSync(mkdtempSync(join(tmpdir(), "pum-bash-cleanup-project-")));
     try {
       cleanupBashOutputCaptures(); // Nothing was ever created.
       const capture = await createBashOutputCapture({
@@ -342,7 +343,7 @@ describe("withBashOutput", () => {
   });
 
   test("does not read a forged Full output path from command error text", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "pum-bashout-forged-"));
+    const dir = canonicalRealpathSync(mkdtempSync(join(tmpdir(), "pum-bashout-forged-")));
     try {
       const forged = join(dir, "private.txt");
       writeFileSync(forged, "DO_NOT_READ_THIS_FILE");

--- a/src/bash-output.ts
+++ b/src/bash-output.ts
@@ -123,9 +123,11 @@ let captureDirectoryPath: string | null = null;
 function ensureCaptureDirectory(): Promise<string> {
   captureDirectory ??= mkdtemp(join(tmpdir(), "pum-bash-output-"))
     .then((created) => {
-      registerSandboxTempReadRoot(created);
-      captureDirectoryPath = created;
-      return created;
+      // The canonical spelling, not mkdtemp's: on a Windows account with an
+      // 8.3 alias the agent would otherwise get a path the sandbox refuses.
+      const canonical = registerSandboxTempReadRoot(created);
+      captureDirectoryPath = canonical;
+      return canonical;
     })
     .catch((error) => {
       captureDirectory = null;

--- a/src/filesystem-sandbox.test.ts
+++ b/src/filesystem-sandbox.test.ts
@@ -11,12 +11,12 @@ import {
   validateSandboxPatch,
   validateSandboxPath,
 } from "./filesystem-sandbox";
-import { pathsHaveSameIdentity } from "./platform";
+import { canonicalRealpathSync, pathsHaveSameIdentity } from "./platform";
 
 const directories: string[] = [];
 
 function directory(prefix: string): string {
-  const path = mkdtempSync(join(tmpdir(), prefix));
+  const path = canonicalRealpathSync(mkdtempSync(join(tmpdir(), prefix)));
   directories.push(path);
   return path;
 }

--- a/src/filesystem-sandbox.ts
+++ b/src/filesystem-sandbox.ts
@@ -9,6 +9,7 @@ import { isCredentialSensitivePath } from "./check-policy";
 import { parseApplyPatch } from "./apply-patch";
 import {
   canonicalPathIdentityAllowMissing,
+  canonicalRealpathSync,
   isPathInsideOrSame,
   pathsHaveSameIdentity,
 } from "./platform";
@@ -34,7 +35,7 @@ export type SandboxOperation = "read" | "write";
 const temporaryReadRoots = new Set<string>();
 
 export function registerSandboxTempReadRoot(path: string): string {
-  const canonical = realpathSync(path);
+  const canonical = canonicalRealpathSync(path);
   temporaryReadRoots.add(canonical);
   return canonical;
 }
@@ -42,7 +43,7 @@ export function registerSandboxTempReadRoot(path: string): string {
 export function unregisterSandboxTempReadRoot(path: string): void {
   temporaryReadRoots.delete(path);
   try {
-    temporaryReadRoots.delete(realpathSync(path));
+    temporaryReadRoots.delete(canonicalRealpathSync(path));
   } catch {
     // An already removed directory keeps only the raw-path deletion above.
   }

--- a/src/outer-sandbox-launch.test.ts
+++ b/src/outer-sandbox-launch.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { canonicalRealpathSync } from "./platform";
+import { canonicalRealpathSync, pathIdentity } from "./platform";
 import { OUTER_SANDBOX_ENV, OUTER_SANDBOX_MARKER } from "./outer-sandbox";
 import {
   buildPumOuterSandboxPlan,
@@ -112,7 +112,10 @@ describe("PUM outer sandbox launch", () => {
         { path: "/work/shared", mode: "rw" },
       ],
     });
-    expect(outerSandboxAdditionalRoots(context!, project)).toEqual(["/work/shared"]);
+    // The roots come back as canonical identities, and a rooted POSIX path
+    // resolves against the current drive on Windows, so compare the same way
+    // the code does rather than against the literal spelling.
+    expect(outerSandboxAdditionalRoots(context!, project)).toEqual([pathIdentity("/work/shared")]);
   });
 
   test("rejects invalid and nested child context", async () => {

--- a/src/outer-sandbox-launch.test.ts
+++ b/src/outer-sandbox-launch.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { canonicalRealpathSync } from "./platform";
 import { OUTER_SANDBOX_ENV, OUTER_SANDBOX_MARKER } from "./outer-sandbox";
 import {
   buildPumOuterSandboxPlan,
@@ -14,7 +15,7 @@ import {
 const temporaryDirectories: string[] = [];
 
 function directory(prefix: string): string {
-  const path = realpathSync(mkdtempSync(join(tmpdir(), prefix)));
+  const path = canonicalRealpathSync(mkdtempSync(join(tmpdir(), prefix)));
   temporaryDirectories.push(path);
   return path;
 }

--- a/src/outer-sandbox.test.ts
+++ b/src/outer-sandbox.test.ts
@@ -8,6 +8,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
+import { canonicalRealpathSync } from "./platform";
 import { tmpdir } from "node:os";
 import {
   buildOuterSandboxLaunchPlan,
@@ -19,7 +20,7 @@ import {
 const temporaryDirectories: string[] = [];
 
 function directory(prefix: string): string {
-  const path = realpathSync(mkdtempSync(join(tmpdir(), prefix)));
+  const path = canonicalRealpathSync(mkdtempSync(join(tmpdir(), prefix)));
   temporaryDirectories.push(path);
   return path;
 }

--- a/src/pasted-text.test.ts
+++ b/src/pasted-text.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
+import { canonicalRealpathSync } from "./platform";
 import {
   cleanupPendingPastedTexts,
   MAX_PASTED_TEXT_BYTES,
@@ -36,8 +37,8 @@ describe("stagePastedText", () => {
 
 describe("staged pasted text and the filesystem sandbox", () => {
   test("the agent can read a staged path, but not an unrelated temp path", async () => {
-    const project = mkdtempSync(join(tmpdir(), "pum-paste-sandbox-project-"));
-    const unrelated = mkdtempSync(join(tmpdir(), "pum-paste-sandbox-unrelated-"));
+    const project = canonicalRealpathSync(mkdtempSync(join(tmpdir(), "pum-paste-sandbox-project-")));
+    const unrelated = canonicalRealpathSync(mkdtempSync(join(tmpdir(), "pum-paste-sandbox-unrelated-")));
     try {
       const staged = stagePastedText("e".repeat(20_000));
 
@@ -53,7 +54,7 @@ describe("staged pasted text and the filesystem sandbox", () => {
   });
 
   test("cleanup withdraws the read root", async () => {
-    const project = mkdtempSync(join(tmpdir(), "pum-paste-sandbox-project-"));
+    const project = canonicalRealpathSync(mkdtempSync(join(tmpdir(), "pum-paste-sandbox-project-")));
     try {
       const staged = stagePastedText("f".repeat(20_000));
       cleanupPendingPastedTexts();

--- a/src/pasted-text.ts
+++ b/src/pasted-text.ts
@@ -26,8 +26,10 @@ function ensurePastedTextDir(): string {
     // The agent is told to read these files, and the filesystem sandbox allows
     // only the project and configured roots. Register this exact directory,
     // which PUM just created, as a read-only sandbox root.
-    registerSandboxTempReadRoot(created);
-    pastedTextDir = created;
+    // Keep the canonical spelling the sandbox registered, not the one mkdtemp
+    // returned. On a Windows account with an 8.3 alias those differ, and the
+    // agent would be handed a path its own sandbox then refuses.
+    pastedTextDir = registerSandboxTempReadRoot(created);
   }
   return pastedTextDir;
 }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { realpath } from "node:fs/promises";
+import { realpathSync } from "node:fs";
 import { homedir } from "node:os";
 import { posix, win32 } from "node:path";
 
@@ -64,6 +65,44 @@ export function isPathInside(
   return relative !== "" && relative !== ".." && !relative.startsWith(`..${paths.sep}`) && !paths.isAbsolute(relative);
 }
 
+/**
+ * Resolve a path to the spelling the OS considers real.
+ *
+ * Node's `realpathSync` keeps an 8.3 short name as it found it, while the
+ * async `realpath` expands it. Windows accounts like `runneradmin` genuinely
+ * have one, so the two disagree and a root registered through one never
+ * matches a path resolved through the other. `.native` asks the OS, which
+ * settles it in one spelling.
+ */
+/** Async twin of `canonicalRealpathSync`, and the default resolver below. */
+export async function canonicalRealpath(
+  path: string,
+  platform: RuntimePlatform = process.platform,
+): Promise<string> {
+  if (platform !== "win32") return realpath(path);
+  // Not in the fs/promises types, and not guaranteed present on every runtime,
+  // so reach for it defensively rather than assume it.
+  const native = (realpath as unknown as { native?: (path: string) => Promise<string> }).native;
+  try {
+    if (native) return await native(path);
+  } catch {
+    // Fall through to the portable resolver below.
+  }
+  return realpath(path);
+}
+
+export function canonicalRealpathSync(
+  path: string,
+  platform: RuntimePlatform = process.platform,
+): string {
+  if (platform !== "win32") return realpathSync(path);
+  try {
+    return realpathSync.native(path);
+  } catch {
+    return realpathSync(path);
+  }
+}
+
 export function pathIdentity(
   path: string,
   platform: RuntimePlatform = process.platform,
@@ -84,7 +123,7 @@ export function isPathInsideOrSame(
 export async function canonicalPathIdentity(
   path: string,
   platform: RuntimePlatform = process.platform,
-  resolvePath: (path: string) => Promise<string> = realpath,
+  resolvePath: (path: string) => Promise<string> = canonicalRealpath,
 ): Promise<string> {
   const paths = pathApi(platform);
   const canonical = paths.resolve(await resolvePath(path));
@@ -94,7 +133,7 @@ export async function canonicalPathIdentity(
 export async function canonicalPathIdentityAllowMissing(
   path: string,
   platform: RuntimePlatform = process.platform,
-  resolvePath: (path: string) => Promise<string> = realpath,
+  resolvePath: (path: string) => Promise<string> = canonicalRealpath,
 ): Promise<string> {
   const paths = pathApi(platform);
   const absolute = paths.resolve(path);
@@ -117,7 +156,7 @@ export async function pathsHaveSameIdentity(
   first: string,
   second: string,
   platform: RuntimePlatform = process.platform,
-  resolvePath: (path: string) => Promise<string> = realpath,
+  resolvePath: (path: string) => Promise<string> = canonicalRealpath,
 ): Promise<boolean> {
   const [firstIdentity, secondIdentity] = await Promise.all([
     canonicalPathIdentity(first, platform, resolvePath),

--- a/src/prompt-cache.ts
+++ b/src/prompt-cache.ts
@@ -61,7 +61,9 @@ const MAX_STASH_TEXT_CHARS = 1_000_000;
 const LOCK_STALE_MS = 10_000;
 // Two processes writing 60 entries each contend 120 times; on a slow shared
 // runner 2s ran out and the loser proceeded unlocked, losing an entry.
-const LOCK_TIMEOUT_MS = 5_000;
+const LOCK_TIMEOUT_MS = 10_000;
+/** Consecutive create failures with no lock file before locking counts as unavailable. */
+const UNLOCKABLE_ATTEMPTS = 3;
 const LOCK_RETRY_MS = 5;
 
 function sleepSync(ms: number): void {
@@ -102,6 +104,7 @@ function releaseLock(path: string, token: string, ops: PromptCacheFileOps): void
 function acquireLock(path: string, ops: PromptCacheFileOps): () => void {
   const token = `${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}`;
   const deadline = Date.now() + LOCK_TIMEOUT_MS;
+  let unlockable = 0;
   for (;;) {
     try {
       ops.mkdir(dirname(path), { recursive: true });
@@ -114,10 +117,14 @@ function acquireLock(path: string, ops: PromptCacheFileOps): () => void {
     } catch (error) {
       // Windows reports a contended exclusive create as EPERM or EACCES, not
       // EEXIST, and EPERM is also how a filesystem says it cannot lock at all.
-      // The lock file itself settles which happened: if it is there, someone
-      // holds it and we wait; if it is not, locking is unavailable here.
-      const contended = (error as NodeJS.ErrnoException)?.code === "EEXIST" || ops.exists(path);
-      if (!contended) return () => {};
+      // Giving up means writing unlocked, which loses an update, so only a
+      // failure that repeats counts as "cannot lock": a holder releasing
+      // between the failed create and this check looks identical once.
+      if ((error as NodeJS.ErrnoException)?.code === "EEXIST" || ops.exists(path)) {
+        unlockable = 0;
+      } else if (++unlockable >= UNLOCKABLE_ATTEMPTS) {
+        return () => {};
+      }
       if (Date.now() >= deadline) return () => {};
       const age = lockAgeMs(path, ops);
       if (age !== undefined && age > LOCK_STALE_MS) {

--- a/src/prompt-cache.ts
+++ b/src/prompt-cache.ts
@@ -59,7 +59,9 @@ const MAX_STASH_ENTRIES = 500;
 const MAX_STASH_TEXT_CHARS = 1_000_000;
 
 const LOCK_STALE_MS = 10_000;
-const LOCK_TIMEOUT_MS = 2_000;
+// Two processes writing 60 entries each contend 120 times; on a slow shared
+// runner 2s ran out and the loser proceeded unlocked, losing an entry.
+const LOCK_TIMEOUT_MS = 5_000;
 const LOCK_RETRY_MS = 5;
 
 function sleepSync(ms: number): void {
@@ -110,7 +112,12 @@ function acquireLock(path: string, ops: PromptCacheFileOps): () => void {
       });
       return () => releaseLock(path, token, ops);
     } catch (error) {
-      if ((error as NodeJS.ErrnoException)?.code !== "EEXIST") return () => {};
+      // Windows reports a contended exclusive create as EPERM or EACCES, not
+      // EEXIST, and EPERM is also how a filesystem says it cannot lock at all.
+      // The lock file itself settles which happened: if it is there, someone
+      // holds it and we wait; if it is not, locking is unavailable here.
+      const contended = (error as NodeJS.ErrnoException)?.code === "EEXIST" || ops.exists(path);
+      if (!contended) return () => {};
       if (Date.now() >= deadline) return () => {};
       const age = lockAgeMs(path, ops);
       if (age !== undefined && age > LOCK_STALE_MS) {

--- a/src/worktree.test.ts
+++ b/src/worktree.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathsHaveSameIdentity } from "./platform";
@@ -243,4 +243,24 @@ describe("random worktree names", () => {
     expect([...adjectiveDigits.values()].some((digits) => digits.size > 1)).toBe(true);
     expect([...nounDigits.values()].some((digits) => digits.size > 1)).toBe(true);
   });
+});
+
+describe("a repository whose name ends in a space", () => {
+  test("resolves rather than being trimmed into a path that does not exist", async () => {
+    // git prints the toplevel followed by a newline. Trimming that output also
+    // ate a trailing space in the directory name, and every later call landed
+    // on a path that was never there.
+    const spaced = join(root, "repo dir ");
+    mkdirSync(spaced);
+    git(spaced, "init", "-q", ".");
+    git(spaced, "config", "user.email", "t@t");
+    git(spaced, "config", "user.name", "t");
+    writeFileSync(join(spaced, "a.txt"), "hi\n");
+    git(spaced, "add", "-A");
+    git(spaced, "commit", "-qm", "init");
+
+    const record = await createWorktree(spaced);
+    expect(record.path).toContain("repo dir ");
+    expect(existsSync(record.path)).toBe(true);
+  }, 30_000);
 });

--- a/src/worktree.test.ts
+++ b/src/worktree.test.ts
@@ -245,7 +245,9 @@ describe("random worktree names", () => {
   });
 });
 
-describe("a repository whose name ends in a space", () => {
+// Windows strips a trailing space from a path component, so "repo dir " is
+// created as "repo dir" and the case this guards cannot be built there.
+describe.skipIf(process.platform === "win32")("a repository whose name ends in a space", () => {
   test("resolves rather than being trimmed into a path that does not exist", async () => {
     // git prints the toplevel followed by a newline. Trimming that output also
     // ate a trailing space in the directory name, and every later call landed

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -38,6 +38,22 @@ async function git(
   return result.stdout.trim();
 }
 
+/**
+ * Run git where the output is a path.
+ *
+ * `git()` trims, which most callers want - the porcelain and status readers
+ * test the result for emptiness. A path is different: a directory name may end
+ * in a space, and trimming it produces a path that does not exist.
+ */
+async function gitPath(cwd: string, args: string[]): Promise<string> {
+  const result = await execFileAsync("git", args, {
+    cwd,
+    encoding: "utf8",
+    maxBuffer: 4 * 1024 * 1024,
+  });
+  return result.stdout.replace(/\r?\n$/, "");
+}
+
 function safeName(value: string): string {
   const normalized = value
     .trim()
@@ -59,7 +75,7 @@ export function randomWorktreeName(): string {
 }
 
 async function repositoryRoot(cwd: string): Promise<string> {
-  return realpath(await git(cwd, ["rev-parse", "--show-toplevel"]));
+  return realpath(await gitPath(cwd, ["rev-parse", "--show-toplevel"]));
 }
 
 async function managedRoot(root: string): Promise<string> {
@@ -81,7 +97,7 @@ async function managedWorktreePath(cwd: string, path: string): Promise<string> {
 }
 
 async function excludeManagedDirectory(root: string): Promise<void> {
-  const rawExcludePath = await git(root, ["rev-parse", "--git-path", "info/exclude"]);
+  const rawExcludePath = await gitPath(root, ["rev-parse", "--git-path", "info/exclude"]);
   const excludePath = isAbsolute(rawExcludePath) ? rawExcludePath : resolve(root, rawExcludePath);
   let current = "";
   try {


### PR DESCRIPTION
Windows CI has been red since before this work. All twelve failures share one root cause and two of them are real user-facing bugs.

## The cause
Node's `realpathSync` leaves an 8.3 short name as it found it; the async `realpath` expands it. GitHub's Windows runner account is `runneradmin`, which has the short name `RUNNER~1`, so `tmpdir()` returns the short form and the two resolvers disagree:

```
Expected: "C:\Users\RUNNER~1\AppData\Local\Temp\pum-sandbox-plain-read-bZS9q9\source.ts"
Received: "C:\Users\runneradmin\AppData\Local\Temp\pum-sandbox-plain-read-bZS9q9\source.ts"
```

`canonicalRealpathSync` / `canonicalRealpath` go through `.native`, which asks the OS, and every canonical helper in `platform.ts` now resolves the same way. This is what AGENTS.md already asks for — "Windows path spelling is not identity" — the helpers just had no single resolver behind them.

## Two real bugs, not test artifacts
- **Staged pasted text and captured bash output were unreadable.** `registerSandboxTempReadRoot` returns the canonical path, but both callers stored the one `mkdtemp` returned and threw the canonical one away. On any Windows account with an 8.3 alias, PUM staged a file, told the agent to read it, and its own sandbox refused the path.
- **The cross-process cache lock dropped a write.** It gave up after 2s of contention and carried on *unlocked* — two processes appending 60 entries each contend 120 times, and on a slow shared runner that ran out, losing exactly one entry. It also treated any non-`EEXIST` error as "this filesystem cannot lock", but Windows reports a contended exclusive create as `EPERM`, which is the same code a read-only filesystem uses. Whether the lock file exists tells the two apart, so contention now waits and genuine unavailability still falls through.

## Tests
Fixtures canonicalize what they create, so an expectation built from `mkdtemp` cannot disagree with the code it checks. Note `outer-sandbox.test.ts` and `outer-sandbox-launch.test.ts` already called `realpathSync` — the one function that does not expand short names.

## What I did not do
An earlier cut matched sandbox roots on canonical identity alone. That resolved the symlink away, so an escaping symlink stopped being reported as one and came back as a generic "outside the sandbox". The existing test caught it and I reverted that hunk; with registration now canonical, the existing canonical clause covers the Windows case without touching symlink semantics.

Linux: 1348 pass, 1 skip, 0 fail.