### PR TITLE
Let the main agent move its own session

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,6 +214,12 @@ These were chosen deliberately. Change them only on purpose.
   its branch and any uncommitted work alone. One layer only, main agent only,
   idle only, and refused while any managed child is retained. `start` and
   `return` are reserved words, never worktree names.
+- **A tool-driven move waits for the turn that asked for it.** `worktree` with
+  `start` or `return` records the intent and returns; the App moves the session
+  from the settle handler. The calling turn has to finish against the directory
+  it began in, or the rest of it runs against roots that changed underneath.
+  Managed children, mutable or not, are refused: a delegate does not get to
+  move the session it is not running in.
 - **The active directory is state, not `process.cwd()`.** Everything
   directory-dependent reads it, so a move rebinds by re-render. A relocated
   session keeps its source repository writable for that process only; this

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to PUM are documented in this file.
 ## [Unreleased]
 
 ### Added
+- Added `worktree` tool actions `start` and `return`, so the main agent can move its own session. The move is scheduled and happens once the calling turn ends, never in the middle of it. Managed children cannot use them.
 - Added `/worktree start [directory]` and `/worktree return`, which move the running session into a generated worktree and back. The session keeps its id, transcript, goal, todo list and settings; nothing is copied or forked. Returning leaves the worktree, its branch and any uncommitted work untouched, so it can still be inspected, merged or removed later. The source repository stays writable while the session runs in the worktree.
 - Added per-agent todo lists. A hidden `Todo` tool group gives the main agent and each managed child `todo_list`, `todo_add`, `todo_update`, `todo_complete` and `todo_delete`, each bound to its own session so no agent can read or change another's plan. Readonly children keep the tools. `Ctrl+O` and `/todo` open a view-only popup for the selected transcript, with `f` to filter.
 - Added `/afk`, which answers model questionnaires while you are away. Each questionnaire goes to one fresh delegate holding a single tool - no files, no shell, no network, no delegation. `/afk` alone toggles it, `/afk <instructions>` starts or re-steers it, and any failure hands the questionnaire straight back to you. AFK is process-local: it is never written to disk and never survives a restart.

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1780,6 +1780,13 @@ export function App({
             const current = goalRef.current;
             if (current?.state === "active") persistGoal(noteSettledWork(current));
           }
+          // The turn is over, so a move the model asked for can happen now.
+          // Run it before scheduling a judge: the judge should read the
+          // repository the session actually ends up in.
+          if (pendingRelocationRef.current) {
+            runPendingRelocation();
+            break;
+          }
           maybeScheduleGoalJudge();
           break;
         }
@@ -2090,6 +2097,48 @@ export function App({
       if (moved) applyRelocation(record);
     })();
   }, [session, relocation?.id]);
+
+  /**
+   * A move the model asked for, held until its turn settles.
+   *
+   * The tool call must finish against the directory it started in, so the
+   * request is only recorded here and acted on from the settle handler.
+   */
+  const pendingRelocationRef = useRef<{ action: "start" | "return"; directory?: string } | null>(null);
+
+  useEffect(() => {
+    subagentManager.setRelocationRequestHandler?.((request) => {
+      const guardInput = {
+        relocation: relocationRef.current,
+        // The tool runs mid-turn by definition, so the idle rule is checked
+        // against everything except that turn.
+        busy: false,
+        retainedChildren: subagentManager.getAgents().length,
+        inFlight: relocatingRef.current || pendingRelocationRef.current !== null,
+      };
+      const blocked = request.action === "start"
+        ? startRelocationBlockReason(guardInput)
+        : returnRelocationBlockReason(guardInput);
+      if (blocked) return { accepted: false, message: blocked };
+      pendingRelocationRef.current = request;
+      return {
+        accepted: true,
+        message: request.action === "start"
+          ? "A fresh worktree will be created and this session moved into it once this turn ends."
+          : "This session will move back to its source repository once this turn ends.",
+      };
+    });
+    return () => subagentManager.setRelocationRequestHandler?.(undefined);
+  }, [subagentManager]);
+
+  const runPendingRelocation = () => {
+    const request = pendingRelocationRef.current;
+    if (!request) return;
+    pendingRelocationRef.current = null;
+    void runWorktreeRelocation(request.action === "start"
+      ? { kind: "start", ...(request.directory ? { directory: request.directory } : {}) }
+      : { kind: "return" });
+  };
 
   const update = (patch: Partial<PumSettings>) => {
     const next = { ...settingsRef.current, ...patch };

--- a/src/git-branch.ts
+++ b/src/git-branch.ts
@@ -44,6 +44,18 @@ export function watchBranch(cwd: string, onChange: () => void): () => void {
       clearTimeout(timer);
       timer = setTimeout(onChange, 100);
     });
+    // The watched directory can go away under us - a relocated session watches
+    // a worktree, and /worktree remove deletes one. Windows reports that as an
+    // asynchronous error event rather than a throw here, and an unhandled one
+    // takes the process down. Losing the watcher only costs a stale branch.
+    watcher.on("error", () => {
+      clearTimeout(timer);
+      try {
+        watcher.close();
+      } catch {
+        // Already closed by the failure that raised the error.
+      }
+    });
     return () => {
       clearTimeout(timer);
       watcher.close();

--- a/src/relocation-ui.test.tsx
+++ b/src/relocation-ui.test.tsx
@@ -46,6 +46,7 @@ function repository(): string {
 }
 
 function fakeSession() {
+  const listeners: ((event: unknown) => void)[] = [];
   const directory = canonicalRealpathSync(mkdtempSync(join(tmpdir(), "pum-reloc-session-")));
   directories.push(directory);
   return {
@@ -58,7 +59,13 @@ function fakeSession() {
     sessionManager: { buildContextEntries: () => [], getEntries: () => [] },
     sessionFile: join(directory, "session.jsonl"),
     sessionId: "current-session",
-    subscribe: () => () => {},
+    subscribe(listener: (event: unknown) => void) {
+      listeners.push(listener);
+      return () => {};
+    },
+    emit(event: unknown) {
+      for (const listener of [...listeners]) listener(event);
+    },
     setThinkingLevel() {},
     setModel: async () => {},
     clearQueue: () => ({ steering: [], followUp: [] }),
@@ -85,6 +92,7 @@ async function renderApp(options: {
 } ) {
   const session = options.session ?? fakeSession();
   const relocated: string[] = [];
+  const relocationHandler: { current?: (request: unknown) => { accepted: boolean; message: string } } = {};
   const setup = await createTestRenderer({ width: 100, height: 28, kittyKeyboard: true });
   destroy = () => setup.renderer.destroy();
   const manager = {
@@ -94,6 +102,7 @@ async function renderApp(options: {
     abortAgent: async () => {},
     sendUserMessage: async () => {},
     persistToolEvent() {},
+    setRelocationRequestHandler(handler: any) { relocationHandler.current = handler; },
   } as any;
   createRoot(setup.renderer).render(
     <App
@@ -122,7 +131,7 @@ async function renderApp(options: {
     />,
   );
   await settle(setup);
-  return { setup, session, relocated };
+  return { setup, session, relocated, relocationHandler };
 }
 
 async function type(setup: Awaited<ReturnType<typeof createTestRenderer>>, text: string) {
@@ -238,3 +247,53 @@ describe("/worktree start and return", () => {
     expect(existsSync(relocationFileFor(session.sessionFile))).toBe(false);
   }, 30_000);
 });
+
+describe("the worktree tool actions", () => {
+  test("schedule the move instead of doing it mid-turn", async () => {
+    const repo = repository();
+    const { setup, session, relocated, relocationHandler } = await renderApp({ cwd: repo });
+
+    const answer = relocationHandler.current!({ action: "start" });
+    expect(answer.accepted).toBe(true);
+    expect(answer.message).toContain("once this turn ends");
+    await settle(setup);
+    // Nothing has moved: the calling turn must finish against the directory it
+    // started in, or the rest of it runs against roots that changed underneath.
+    expect(relocated).toEqual([]);
+    expect(loadRelocation(session.sessionFile)).toBeNull();
+
+    session.emit({ type: "agent_settled" });
+    await settle(setup);
+    await settle(setup);
+
+    const record = loadRelocation(session.sessionFile);
+    expect(record?.location).toBe("worktree");
+    expect(relocated).toEqual([record!.worktreePath]);
+  }, 30_000);
+
+  test("refuse rather than schedule when a rule blocks the move", async () => {
+    const repo = repository();
+    const { setup, session, relocated, relocationHandler } = await renderApp({ cwd: repo });
+
+    // Returning from a session that never moved.
+    const refused = relocationHandler.current!({ action: "return" });
+    expect(refused.accepted).toBe(false);
+    expect(refused.message).toContain("not running in a generated worktree");
+
+    session.emit({ type: "agent_settled" });
+    await settle(setup);
+    expect(relocated).toEqual([]);
+    expect(loadRelocation(session.sessionFile)).toBeNull();
+    expect(setup).toBeDefined();
+  }, 30_000);
+
+  test("only one move is ever in flight", async () => {
+    const repo = repository();
+    const { relocationHandler } = await renderApp({ cwd: repo });
+    expect(relocationHandler.current!({ action: "start" }).accepted).toBe(true);
+    const second = relocationHandler.current!({ action: "start" });
+    expect(second.accepted).toBe(false);
+    expect(second.message).toContain("already in progress");
+  }, 30_000);
+});
+

--- a/src/relocation-ui.test.tsx
+++ b/src/relocation-ui.test.tsx
@@ -97,7 +97,10 @@ async function renderApp(options: {
   const session = options.session ?? fakeSession();
   const relocated: string[] = [];
   const relocationHandler: { current?: (request: unknown) => { accepted: boolean; message: string } } = {};
-  const setup = await createTestRenderer({ width: 100, height: 28, kittyKeyboard: true });
+  // Wide enough that the status bar never shreds the directory and branch to
+  // fit. A Windows temp path is long, and this assertion is about rebinding,
+  // not about how the bar sheds segments under pressure.
+  const setup = await createTestRenderer({ width: 200, height: 28, kittyKeyboard: true });
   destroy = () => setup.renderer.destroy();
   const manager = {
     getAgents: () => options.agents ?? [],

--- a/src/relocation-ui.test.tsx
+++ b/src/relocation-ui.test.tsx
@@ -15,7 +15,11 @@ afterEach(() => {
   destroy?.();
   destroy = undefined;
   for (const directory of directories.splice(0)) {
-    rmSync(directory, { recursive: true, force: true, maxRetries: process.platform === "win32" ? 10 : 0 });
+    try {
+      rmSync(directory, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+    } catch {
+      // A leftover temp directory is harmless; failing teardown is not.
+    }
   }
 });
 
@@ -134,11 +138,33 @@ async function renderApp(options: {
   return { setup, session, relocated, relocationHandler };
 }
 
+async function settleUntil(
+  setup: Awaited<ReturnType<typeof createTestRenderer>>,
+  done: () => boolean,
+  timeoutMs = 20_000,
+) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    await settle(setup);
+    if (done()) return;
+  }
+  throw new Error(`relocation did not settle: ${setup.captureCharFrame()}`);
+}
+
 async function type(setup: Awaited<ReturnType<typeof createTestRenderer>>, text: string) {
   await setup.mockInput.typeText(text);
   setup.mockInput.pressEnter();
   await settle(setup);
-  await settle(setup);
+}
+
+/** Send a command and wait for the move it starts to actually land. */
+async function typeAndSettleMove(
+  setup: Awaited<ReturnType<typeof createTestRenderer>>,
+  text: string,
+  done: () => boolean,
+) {
+  await type(setup, text);
+  await settleUntil(setup, done);
 }
 
 describe("/worktree start and return", () => {
@@ -146,7 +172,7 @@ describe("/worktree start and return", () => {
     const repo = repository();
     const { setup, session, relocated } = await renderApp({ cwd: repo });
 
-    await type(setup, "/worktree start");
+    await typeAndSettleMove(setup, "/worktree start", () => loadRelocation(session.sessionFile) !== null);
     const record = loadRelocation(session.sessionFile);
     expect(record?.location).toBe("worktree");
     expect(record?.branch).toMatch(/^pum\//);
@@ -157,7 +183,7 @@ describe("/worktree start and return", () => {
     // that a worktree was created somewhere.
     expect(setup.captureCharFrame()).toContain(`${record!.name} · ${record!.branch}`);
 
-    await type(setup, "/worktree return");
+    await typeAndSettleMove(setup, "/worktree return", () => relocated.length > 1);
     expect(relocated[1]).toBe(repo);
     // Returning preserves the worktree; only the session moved.
     expect(existsSync(record!.worktreePath)).toBe(true);
@@ -167,9 +193,10 @@ describe("/worktree start and return", () => {
 
   test("refuses a second layer", async () => {
     const repo = repository();
-    const { setup } = await renderApp({ cwd: repo });
-    await type(setup, "/worktree start");
-    await type(setup, "/worktree start");
+    const { setup, session } = await renderApp({ cwd: repo });
+    await typeAndSettleMove(setup, "/worktree start", () => loadRelocation(session.sessionFile) !== null);
+    await typeAndSettleMove(setup, "/worktree start",
+      () => setup.captureCharFrame().includes("return first"));
     expect(setup.captureCharFrame()).toContain("return first");
   }, 30_000);
 
@@ -204,7 +231,8 @@ describe("/worktree start and return", () => {
   test("keeps the worktree when the move itself fails", async () => {
     const repo = repository();
     const { setup, session } = await renderApp({ cwd: repo, onRelocate: async () => null });
-    await type(setup, "/worktree start");
+    await typeAndSettleMove(setup, "/worktree start",
+      () => setup.captureCharFrame().includes("did not move"));
 
     const frame = setup.captureCharFrame();
     expect(frame).toContain("did not move");
@@ -263,8 +291,7 @@ describe("the worktree tool actions", () => {
     expect(loadRelocation(session.sessionFile)).toBeNull();
 
     session.emit({ type: "agent_settled" });
-    await settle(setup);
-    await settle(setup);
+    await settleUntil(setup, () => loadRelocation(session.sessionFile) !== null);
 
     const record = loadRelocation(session.sessionFile);
     expect(record?.location).toBe("worktree");

--- a/src/subagents/manager.ts
+++ b/src/subagents/manager.ts
@@ -50,7 +50,7 @@ import {
   afkAllowedToolNames,
   judgeAllowedToolNames,
 } from "../tool-groups";
-import { isInternalRole } from "./types";
+import { isInternalRole, type RelocationRequest, type RelocationRequestResult } from "./types";
 import { AFK_ANSWER_TOOL_NAME, afkAnswerParameters } from "../afk-delegate";
 import { TodoToolsController } from "../todo-tools";
 import {
@@ -350,6 +350,12 @@ export class SubagentManager {
   private mainApi?: ExtensionAPI;
   private mainSessionManager?: ExtensionContext["sessionManager"];
   private mainCwd = process.cwd();
+  /**
+   * Set by App. The tool records an intent and returns; the move happens after
+   * the calling turn settles, because changing roots inside a live model call
+   * would leave the rest of that turn running against the old directory.
+   */
+  private relocationRequest?: (request: RelocationRequest) => RelocationRequestResult;
   private parentSessionId = "detached";
   private mainRunning = false;
   private readonly mainCompletionMessageIds = new Set<string>();
@@ -1556,16 +1562,24 @@ export class SubagentManager {
         pi.registerTool({
           name: "worktree",
           label: "Worktree",
-          description: "Create, list, inspect, merge, or remove PUM Git worktrees.",
+          description: "Create, list, inspect, merge, or remove PUM Git worktrees. "
+            + "start moves this session into a fresh worktree and return moves it back; "
+            + "both take effect once the current turn ends.",
           promptSnippet: "Manage isolated Git worktrees under .pum/worktrees",
           parameters: Type.Object({
-            action: Type.String({ description: "create, list, status, merge, or remove" }),
+            action: Type.String({ description: "create, list, status, merge, remove, start, or return" }),
             target: Type.Optional(Type.String({ description: "Worktree id or name" })),
             name: Type.Optional(Type.String({ description: "Name for a new worktree" })),
+            directory: Type.Optional(Type.String({ description: "Repository to branch from, for start" })),
             force: Type.Optional(Type.Boolean({ description: "Force removal of an unmerged worktree" })),
           }),
           execute: async (_id, params, _signal, _update, ctx) => {
             await this.attachMain(pi, ctx.sessionManager, ctx.cwd);
+            if (params.action === "start" || params.action === "return") {
+              return this.requestRelocation(params.action === "start"
+                ? { action: "start", ...(params.directory ? { directory: params.directory } : {}) }
+                : { action: "return" });
+            }
             return this.worktreeAction(ctx.cwd, params.action, params.target, params.name, params.force);
           },
         });
@@ -1584,6 +1598,25 @@ export class SubagentManager {
     } finally {
       release();
     }
+  }
+
+  /**
+   * Record a move the main agent asked for. Never performs it: the App moves
+   * the session once this turn settles.
+   */
+  private requestRelocation(request: RelocationRequest) {
+    if (!this.relocationRequest) {
+      throw new Error("This session cannot be moved.");
+    }
+    const result = this.relocationRequest(request);
+    if (!result.accepted) throw new Error(result.message);
+    return textResult(result.message);
+  }
+
+  setRelocationRequestHandler(
+    handler: ((request: RelocationRequest) => RelocationRequestResult) | undefined,
+  ): void {
+    this.relocationRequest = handler;
   }
 
   async createStandaloneWorktree(name?: string): Promise<WorktreeRecord> {
@@ -2964,6 +2997,12 @@ export class SubagentManager {
         if (managedAgent) this.forgetManagedAgent(managedAgent);
         return textResult(`Removed ${record.name}`, record);
       });
+    }
+    if (action === "start" || action === "return") {
+      // Only the authoritative main agent moves the session it is running in.
+      // A child shares no such session, and moving the parent out from under
+      // itself is not something a delegate gets to decide.
+      throw new Error(`Only the main agent can run worktree ${action}`);
     }
     throw new Error(`Unknown worktree action: ${action}`);
   }

--- a/src/subagents/types.ts
+++ b/src/subagents/types.ts
@@ -170,3 +170,18 @@ export type RoutedPrompt = {
   text: string;
   images?: ImageContent[];
 };
+
+/** A move the main agent asked for through the worktree tool. */
+export type RelocationRequest =
+  | { action: "start"; directory?: string }
+  | { action: "return" };
+
+/**
+ * What the App decided. `accepted` false means nothing was scheduled, and the
+ * message says why, so the model learns the rule instead of retrying blind.
+ */
+export type RelocationRequestResult = {
+  accepted: boolean;
+  message: string;
+};
+

--- a/src/tool-line.ts
+++ b/src/tool-line.ts
@@ -147,7 +147,8 @@ export function toolArg(name: string, args: any, cwd: string): string {
   if (name === "stop_subagent" && typeof args.target === "string") return args.target;
   if (name === "finish_subagent" && typeof args.summary === "string") return args.summary;
   if (name === "worktree" && typeof args.action === "string") {
-    const target = args.target ?? args.name;
+    // start carries a directory rather than a target or a name.
+    const target = args.target ?? args.name ?? (args.action === "start" ? args.directory : undefined);
     return target ? `${args.action} ${target}` : args.action;
   }
   if (name.startsWith("message_cache_")) {

--- a/src/worktree-start.test.ts
+++ b/src/worktree-start.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import { canonicalPathIdentity, isPathInside, pathsHaveSameIdentity } from "./platform";
@@ -136,3 +136,27 @@ describe("start message", () => {
     expect(message).toContain(UNCOMMITTED_CHANGES_NOTICE);
   });
 });
+
+describe("the source root is a path, not an identity", () => {
+  test("keeps the spelling the filesystem uses", async () => {
+    // sourceRoot is a directory the session runs and writes in, so it must be
+    // the real spelling. canonicalPathIdentity lowercases on Windows, which is
+    // only ever right for comparing two paths.
+    const repo = mkdtempSync(join(tmpdir(), "PumMixedCase-"));
+    try {
+      execFileSync("git", ["init", "-q", "."], { cwd: repo });
+      execFileSync("git", ["config", "user.email", "t@t"], { cwd: repo });
+      execFileSync("git", ["config", "user.name", "t"], { cwd: repo });
+      writeFileSync(join(repo, "a.txt"), "hi\n");
+      execFileSync("git", ["add", "-A"], { cwd: repo });
+      execFileSync("git", ["commit", "-qm", "init"], { cwd: repo });
+
+      const started = await startWorktree(repo);
+      expect(started.sourceRoot).toContain("PumMixedCase-");
+      expect(existsSync(started.sourceRoot)).toBe(true);
+    } finally {
+      rmSync(repo, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+    }
+  }, 30_000);
+});
+

--- a/src/worktree-start.ts
+++ b/src/worktree-start.ts
@@ -2,7 +2,7 @@ import { execFile } from "node:child_process";
 import { stat } from "node:fs/promises";
 import { resolve } from "node:path";
 import { promisify } from "node:util";
-import { canonicalPathIdentity, isPathInside } from "./platform";
+import { canonicalPathIdentity, canonicalRealpath, isPathInside } from "./platform";
 import { createWorktree, type WorktreeRecord } from "./worktree";
 
 const execFileAsync = promisify(execFile);
@@ -73,7 +73,10 @@ async function repositoryRoot(directory: string): Promise<string> {
     throw new Error(`Cannot start a worktree in ${directory}: it is not inside a git repository`);
   }
   try {
-    return await canonicalPathIdentity(top);
+    // The real spelling, not an identity. This value is used as a directory -
+    // the session runs there and writes there - and canonicalPathIdentity
+    // lowercases on Windows, which is only for comparing two paths.
+    return await canonicalRealpath(top);
   } catch (error) {
     throw new Error(`Cannot start a worktree: repository root ${top} does not resolve: `
       + (error as Error).message);


### PR DESCRIPTION
The `worktree` tool half of #13's relocation work, on top of #31's slash commands.

## Scheduling, not moving
`worktree` with `action: "start"` or `"return"` records the intent and returns a description. The App performs the move from the `agent_settled` handler.

That ordering is the whole point: the calling turn has to finish against the directory it began in. Moving mid-call would leave the rest of that turn — its remaining tool calls, its sandbox roots, its Check mode identity — pointing at a project the session had already left.

The move also runs *before* a goal judge is scheduled, so the judge reads the repository the session actually ended up in rather than the one it was leaving.

## Refusals
Managed children are refused, mutable or not — a delegate does not get to move a session it is not running in. The guards from #31 apply unchanged (one layer, no retained children, one transition in flight), and a blocked request is refused outright rather than scheduled and then silently dropped, so the model learns the rule instead of retrying blind.

## Tests
The scheduling property is asserted directly: after the tool accepts, nothing has moved and no record exists; only after `agent_settled` does the worktree appear and the session relocate.

`bun test`: 1386 pass, 1 skip, 0 fail.

## Still open on #13
The worktree-side resume alias — a relocated session is discoverable from its source repository but not yet from the worktree. That needs `SessionManager.list` to understand a pointer file, and it is the last piece.